### PR TITLE
Make the spin dependency optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ panic = ["alloc"]
 panic-handler = ["print", "panic"]
 panic-handler-dummy = []
 system-alloc = []
-default = ["unwinder", "dwarf-expr", "hide-trace", "fde-phdr", "fde-registry", "spin"]
+default = ["unwinder", "dwarf-expr", "hide-trace", "fde-phdr", "fde-registry"]
 
 [profile.dev]
 # Must be turned on due to Rust bug https://github.com/rust-lang/rust/issues/50007

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = ["cdylib", "example"]
 [dependencies]
 gimli = { version = "0.25.0", default-features = false, features = ["read"] }
 libc = { version = "0.2", optional = true }
-spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] }
+spin = { version = "0.9", optional = true, default-features = false, features = ["mutex", "spin_mutex"] }
 
 [patch.crates-io]
 gimli = { git = "https://github.com/gimli-rs/gimli.git" }
@@ -31,7 +31,7 @@ panic = ["alloc"]
 panic-handler = ["print", "panic"]
 panic-handler-dummy = []
 system-alloc = []
-default = ["unwinder", "dwarf-expr", "hide-trace", "fde-phdr", "fde-registry"]
+default = ["unwinder", "dwarf-expr", "hide-trace", "fde-phdr", "fde-registry", "spin"]
 
 [profile.dev]
 # Must be turned on due to Rust bug https://github.com/rust-lang/rust/issues/50007

--- a/src/unwinder/find_fde/registry.rs
+++ b/src/unwinder/find_fde/registry.rs
@@ -67,6 +67,8 @@ unsafe fn lock_global_state() -> impl ops::DerefMut<Target = GlobalState> {
         });
         MUTEX.lock()
     }
+    #[cfg(not(any(feature = "libc", feature = "spin")))]
+    compile_error!("Either feature \"libc\" or \"spin\" must be enabled to use \"fde-registry\".");
 }
 
 pub fn get_finder() -> &'static Registry {


### PR DESCRIPTION
Make the spin dependency optional so that users enabling libc, which
enables libc-based locking, don't need to depend on spin.