### PR TITLE
Fix compilation on `asm!` for Rust nightly.

### DIFF
--- a/src/unwinder/arch/aarch64.rs
+++ b/src/unwinder/arch/aarch64.rs
@@ -1,3 +1,4 @@
+use core::arch::asm;
 use core::fmt;
 use core::ops;
 use gimli::{AArch64, Register};

--- a/src/unwinder/arch/riscv64.rs
+++ b/src/unwinder/arch/riscv64.rs
@@ -1,3 +1,4 @@
+use core::arch::asm;
 use core::fmt;
 use core::ops;
 use gimli::{Register, RiscV};

--- a/src/unwinder/arch/x86.rs
+++ b/src/unwinder/arch/x86.rs
@@ -1,3 +1,4 @@
+use core::arch::asm;
 use core::fmt;
 use core::ops;
 use gimli::{Register, X86};

--- a/src/unwinder/arch/x86_64.rs
+++ b/src/unwinder/arch/x86_64.rs
@@ -1,3 +1,4 @@
+use core::arch::asm;
 use core::fmt;
 use core::ops;
 use gimli::{Register, X86_64};


### PR DESCRIPTION
Add `use core::arch::asm;` in source files that use `asm!`, to fix
compilation on the latest Rust nightly.