### PR TITLE
Fix print macros without newline

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -30,7 +30,7 @@ macro_rules! println {
 macro_rules! print {
     ($($arg:tt)*) => ({
         use core::fmt::Write;
-        let _ = core::writeln!($crate::print::StdoutPrinter, $($arg)*);
+        let _ = core::write!($crate::print::StdoutPrinter, $($arg)*);
     })
 }
 
@@ -46,6 +46,6 @@ macro_rules! eprintln {
 macro_rules! eprint {
     ($($arg:tt)*) => ({
         use core::fmt::Write;
-        let _ = core::writeln!($crate::print::StderrPrinter, $($arg)*);
+        let _ = core::write!($crate::print::StderrPrinter, $($arg)*);
     })
 }


### PR DESCRIPTION
`print!` and `eprint!` macros were calling `writeln!` instead of `write!`.

Also why `StdoutPrinter` uses `libc::printf` but `StderrPrinter` uses `libc::write`? I think to avoid calling printf is better since the string is already formatted.