### PR TITLE
Unwind support on ARM architecture

### DIFF
--- a/src/arch.rs
+++ b/src/arch.rs
@@ -70,11 +70,31 @@ mod aarch64 {
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::*;
 
+#[cfg(target_arch = "arm")]
+mod arm {
+    use gimli::{Arm, Register};
+
+    pub struct Arch;
+
+    #[allow(unused)]
+    impl Arch {
+        pub const SP: Register = Arm::SP;
+        pub const RA: Register = Arm::R14;
+
+        // TODO: what these do?
+        pub const UNWIND_DATA_REG: (Register, Register) = (Arm::R0, Arm::R1);
+        pub const UNWIND_PRIVATE_DATA_SIZE: usize = 2;
+    }
+}
+#[cfg(target_arch = "arm")]
+pub use arm::*;
+
 #[cfg(not(any(
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
     target_arch = "riscv32",
-    target_arch = "aarch64"
+    target_arch = "aarch64",
+    target_arch = "arm"
 )))]
 compile_error!("Current architecture is not supported");

--- a/src/unwinder/arch/arm.rs
+++ b/src/unwinder/arch/arm.rs
@@ -1,0 +1,88 @@
+use core::arch::asm;
+use core::fmt;
+use core::ops;
+use gimli::{Arm, Register};
+
+// Match FIRST_PSEUDO_REGISTER from GCC
+pub const MAX_REG_RULES: usize = 107;
+
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct Context {
+    pub gp: [usize; 13],
+    pub sp: usize,
+    pub lr: usize,
+    pub pc: usize,
+}
+
+impl ops::Index<Register> for Context {
+    type Output = usize;
+
+    fn index(&self, reg: Register) -> &usize {
+        match reg {
+            Register(0..=12) => &self.gp[reg.0 as usize],
+            Arm::SP => &self.sp,
+            Arm::LR => &self.lr,
+            Arm::PC => &self.pc,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl ops::IndexMut<Register> for Context {
+    fn index_mut(&mut self, reg: Register) -> &mut usize {
+        match reg {
+            Register(0..=12) => &mut self.gp[reg.0 as usize],
+            Arm::SP => &mut self.sp,
+            Arm::LR => &mut self.lr,
+            Arm::PC => &mut self.pc,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+#[naked]
+pub extern "C-unwind" fn save_context() -> Context {
+    // No need to save caller-saved registers here. r9 register is somewhat
+    // special as depending on the platform it may be calle-saved or not,
+    // probably there is no way to detect whether it's calle-saved or not except
+    // by having to support each possible platform which wouldn't work reliably
+    // in no_std environments.
+    //
+    // TODO: support hard fp
+    unsafe {
+        asm!(
+            "
+            str r4, [r0, #0x10]
+            str r5, [r0, #0x14]
+            str r6, [r0, #0x18]
+            str r7, [r0, #0x1C]
+            str r8, [r0, #0x20]
+            str r9, [r0, #0x24]
+            str r10, [r0, #0x28]
+            str r11, [r0, #0x2C]
+            str r12, [r0, #0x30]
+            str sp, [r0, #0x34]
+            str lr, [r0, #0x38]
+            str pc, [r0, #0x3C]
+            bx lr
+            ",
+            options(noreturn)
+        );
+    }
+}
+
+//#[naked]
+pub extern "C-unwind" fn restore_context(ctx: &Context) -> ! {
+    todo!("restore_context")
+}
+
+#[no_mangle]
+pub extern "C-unwind" fn __aeabi_unwind_cpp_pr0() {
+    todo!()
+}
+
+#[no_mangle]
+pub extern "C-unwind" fn __aeabi_unwind_cpp_pr1() {
+    todo!()
+}

--- a/src/unwinder/arch/arm.rs
+++ b/src/unwinder/arch/arm.rs
@@ -1,5 +1,4 @@
 use core::arch::asm;
-use core::fmt;
 use core::ops;
 use gimli::{Arm, Register};
 
@@ -73,16 +72,6 @@ pub extern "C-unwind" fn save_context() -> Context {
 }
 
 //#[naked]
-pub extern "C-unwind" fn restore_context(ctx: &Context) -> ! {
+pub unsafe extern "C-unwind" fn restore_context(_ctx: &Context) -> ! {
     todo!("restore_context")
-}
-
-#[no_mangle]
-pub extern "C-unwind" fn __aeabi_unwind_cpp_pr0() {
-    todo!()
-}
-
-#[no_mangle]
-pub extern "C-unwind" fn __aeabi_unwind_cpp_pr1() {
-    todo!()
 }

--- a/src/unwinder/arch/mod.rs
+++ b/src/unwinder/arch/mod.rs
@@ -18,10 +18,16 @@ mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::*;
 
+#[cfg(target_arch = "arm")]
+mod arm;
+#[cfg(target_arch = "arm")]
+pub use arm::*;
+
 #[cfg(not(any(
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
-    target_arch = "aarch64"
+    target_arch = "aarch64",
+    target_arch = "arm"
 )))]
 compile_error!("Current architecture is not supported");

--- a/src/unwinder/ehabi/finder_static.rs
+++ b/src/unwinder/ehabi/finder_static.rs
@@ -1,0 +1,30 @@
+use super::types::IndexEntry;
+
+extern "C" {
+    fn __exidx_start();
+    fn __exidx_end();
+    static __executable_start: u8;
+    static __etext: u8;
+}
+
+pub fn find_exidx() -> Option<&'static [IndexEntry]> {
+    let base = __exidx_start as usize;
+    let len = __exidx_end as usize - base;
+    assert!(len > 0);
+    assert!(len % 8 == 0);
+
+    let exidx = unsafe { core::slice::from_raw_parts(base as *const IndexEntry, len / 8) };
+    Some(exidx)
+}
+
+pub fn find_entry_for_pc(table: &[IndexEntry], pc: usize) -> Option<&IndexEntry> {
+    unsafe {
+        let text_start = &__executable_start as *const u8 as usize;
+        let text_end = &__etext as *const u8 as usize;
+        if !(text_start..text_end).contains(&pc) {
+            return None;
+        }
+
+        table.iter().rev().find(|x| x.addr() <= pc)
+    }
+}

--- a/src/unwinder/ehabi/mod.rs
+++ b/src/unwinder/ehabi/mod.rs
@@ -1,0 +1,35 @@
+use super::arch::*;
+use crate::abi::PersonalityRoutine;
+
+#[derive(Debug)]
+pub struct Frame {}
+
+impl Frame {
+    pub fn from_context(ctx: &Context, signal: bool) -> Result<Option<Self>, gimli::Error> {
+        todo!()
+    }
+
+    pub fn unwind(&self, ctx: &Context) -> Result<Context, gimli::Error> {
+        todo!()
+    }
+
+    pub fn bases(&self) -> &gimli::read::BaseAddresses {
+        todo!()
+    }
+
+    pub fn personality(&self) -> Option<PersonalityRoutine> {
+        todo!()
+    }
+
+    pub fn lsda(&self) -> usize {
+        todo!()
+    }
+
+    pub fn initial_address(&self) -> usize {
+        todo!()
+    }
+
+    pub fn is_signal_trampoline(&self) -> bool {
+        todo!()
+    }
+}

--- a/src/unwinder/ehabi/mod.rs
+++ b/src/unwinder/ehabi/mod.rs
@@ -1,16 +1,75 @@
+mod finder_static;
+mod types;
+
 use super::arch::*;
 use crate::abi::PersonalityRoutine;
+use crate::arch::*;
 
 #[derive(Debug)]
-pub struct Frame {}
+struct UnwindData {
+    // Personality routine used for unwinding
+    personality_fn_index: u32,
+    // Data to pass to personality routine
+    arg: u32,
+    lsda: usize,
+    cmdbuf: [u8; 4],
+    cmdbuf_len: usize,
+}
+
+#[derive(Debug)]
+pub struct Frame {
+    // Function entrypoint address
+    entrypoint: usize,
+    data: UnwindData,
+}
 
 impl Frame {
     pub fn from_context(ctx: &Context, signal: bool) -> Result<Option<Self>, gimli::Error> {
-        todo!()
+        assert!(!signal);
+
+        let ra = ctx[Arch::RA];
+
+        // Reached end of stack
+        if ra == 0 {
+            return Ok(None);
+        }
+
+        let exidx = finder_static::find_exidx().unwrap();
+        let result = finder_static::find_entry_for_pc(exidx, ra).unwrap();
+
+        let data = result.data;
+        let unwind_data = if data == 1 {
+            return Ok(None);
+        } else if data & (1 << 31) != 0 {
+            let arg = data & 0xffffff;
+            let fn_index = (data >> 24) & 0xf;
+
+            if fn_index != 0 {
+                // TODO: gracefully handle error
+                panic!("Inline entry may use pr0 only")
+            }
+
+            let cmdbuf = [(arg >> 16) as u8, (arg >> 8) as u8, arg as u8, 0];
+
+            UnwindData {
+                personality_fn_index: fn_index,
+                arg,
+                lsda: 0,
+                cmdbuf,
+                cmdbuf_len: 3,
+            }
+        } else {
+            todo!("generic model not supported")
+        };
+
+        Ok(Some(Self {
+            entrypoint: result.addr(),
+            data: unwind_data,
+        }))
     }
 
     pub fn unwind(&self, ctx: &Context) -> Result<Context, gimli::Error> {
-        todo!()
+        Ok(vrs_interpret(ctx, &self.data.cmdbuf[..self.data.cmdbuf_len]).unwrap())
     }
 
     pub fn bases(&self) -> &gimli::read::BaseAddresses {
@@ -26,10 +85,99 @@ impl Frame {
     }
 
     pub fn initial_address(&self) -> usize {
-        todo!()
+        self.entrypoint
     }
 
     pub fn is_signal_trampoline(&self) -> bool {
-        todo!()
+        false
+    }
+}
+
+#[no_mangle]
+pub extern "C-unwind" fn __aeabi_unwind_cpp_pr0() {
+    todo!()
+}
+
+#[no_mangle]
+pub extern "C-unwind" fn __aeabi_unwind_cpp_pr1() {
+    todo!()
+}
+
+fn vrs_interpret(ctx: &Context, code: &[u8]) -> Result<Context, ()> {
+    let mut new_ctx = ctx.clone();
+    let mut it = code.iter().copied();
+    let mut wrote_pc = false;
+
+    'main_loop: while let Some(b) = it.next() {
+        if b & 0x80 == 0 {
+            let adj = ((b & 0x3f) << 2) as usize + 4;
+
+            if b & 0x40 == 0 {
+                new_ctx.sp += adj;
+            } else {
+                new_ctx.sp -= adj;
+            }
+        } else {
+            match b & 0xf0 {
+                0x80 => {
+                    let v = (b & 0xf) as u32;
+                    let mask = (v << 12) | it.next().map(|x| x as u32).ok_or(())?;
+                    if mask & (1 << 15) != 0 {
+                        wrote_pc = true;
+                    }
+                    vrs_pop(&mut new_ctx, mask);
+                }
+                0xa0 => {
+                    let n = ((b & 0x7) + 1) as u32;
+                    let mut mask = ((1 << n) - 1) << 4;
+                    if b & 8 != 0 {
+                        mask |= 1 << 14;
+                    }
+                    vrs_pop(&mut new_ctx, mask);
+                }
+                0xb0 => match b & 0xf {
+                    0 => break 'main_loop,
+                    _ => todo!(),
+                },
+                cmd => todo!("unknown command {:#x}", cmd),
+            }
+        }
+    }
+
+    if !wrote_pc {
+        new_ctx.pc = new_ctx.lr;
+    }
+
+    Ok(new_ctx)
+}
+
+fn vrs_pop(ctx: &mut Context, mask: u32) {
+    let mut sp = ctx.sp as *const usize;
+    let mut sp_popped = false;
+
+    for i in 0..16 {
+        if mask & 1 << i != 0 {
+            let v = unsafe { sp.read() };
+            sp = sp.wrapping_add(1);
+
+            match i {
+                0..=12 => ctx.gp[i] = v,
+                13 => {
+                    sp_popped = true;
+                    ctx.sp = v;
+                }
+                14 => {
+                    ctx.lr = v;
+                }
+                15 => {
+                    ctx.pc = v;
+                }
+                _ => todo!(),
+            }
+        }
+    }
+
+    if !sp_popped {
+        ctx.sp = sp as usize;
     }
 }

--- a/src/unwinder/ehabi/types.rs
+++ b/src/unwinder/ehabi/types.rs
@@ -1,0 +1,14 @@
+#[repr(C)]
+pub struct IndexEntry {
+    offset: u32,
+    pub data: u32,
+}
+
+impl IndexEntry {
+    pub fn addr(&self) -> usize {
+        assert!(self.offset & 1 << 31 == 0);
+        let offset = self.offset | (self.offset & (1 << 30)) << 1;
+
+        (self as *const _ as usize).wrapping_add(offset as usize)
+    }
+}


### PR DESCRIPTION
WIP support for ARM, can do backtrace on basic functions. Eventually, this PR will solve https://github.com/nbdd0121/unwinding/issues/3.

For a working (backtrace) example you can check https://github.com/arturkow2000/qemu-example/pull/1.
You need to
```shell
export DEFMT_LOG=trace
export RUSTFLAGS=-Cforce-unwind-tables=on
```
before building app. For details see README in the repo.