### PR TITLE
Simplify CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,7 @@ jobs:
           - i686-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
-        build_std: [false]
-        include:
-          - target: riscv32gc-unknown-linux-gnu
-            build_std: true
+          - riscv32gc-unknown-linux-gnu
     runs-on: ubuntu-latest
 
     steps:
@@ -26,28 +23,16 @@ jobs:
       run: |
         rustup update nightly
         rustup default nightly
-    - name: Install Rust standard library source
-      if: matrix.build_std
-      run: rustup component add rust-src
     - name: Install cross-compilation tools
       uses: taiki-e/setup-cross-toolchain-action@v1
       with:
         target: ${{ matrix.target }}
 
     - name: Build example binary
-      if: '!matrix.build_std'
-      run: cargo build --release
-    - name: Build example binary
-      if: matrix.build_std
-      run: cargo build --release -Zbuild-std
+      run: cargo build --release $BUILD_STD
 
     - name: Run example binary
-      if: '!matrix.build_std'
-      run: (cargo run --release 2>&1 | tee ../run.log) || true
-      working-directory: example
-    - name: Run example binary
-      if: matrix.build_std
-      run: (cargo run --release -Zbuild-std 2>&1 | tee ../run.log) || true
+      run: (cargo run --release $BUILD_STD 2>&1 | tee ../run.log) || true
       working-directory: example
 
     - name: Check log


### PR DESCRIPTION
setup-cross-toolchain-action sets `BUILD_STD=-Zbuild-std` environment variable and installs `rust-src` component if the target is tier 3 and build-std is needed.

docs: https://github.com/taiki-e/setup-cross-toolchain-action#example-workflow-tier-3-targets
(This environment variable has existed since the initial version of setup-cross-toolchain-action but I forgot to document it for a long time.)