### PR TITLE
Initial libstd support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ members = ["cdylib", "example"]
 gimli = { version = "0.26.1", default-features = false, features = ["read-core"] }
 libc = { version = "0.2", optional = true }
 spin = { version = "0.9.8", optional = true, default-features = false, features = ["mutex", "spin_mutex"] }
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
+compiler_builtins = { version = "0.1.2", optional = true }
 
 [features]
 alloc = []
@@ -36,6 +38,7 @@ panic-handler = ["print", "panic"]
 panic-handler-dummy = []
 system-alloc = []
 default = ["unwinder", "dwarf-expr", "hide-trace", "fde-phdr-dl", "fde-registry"]
+rustc-dep-of-std = ["core", "gimli/rustc-dep-of-std", "compiler_builtins"]
 
 [profile.release]
 debug = true


### PR DESCRIPTION
This PR contains two patches required to allow `unwinding` to be used with `libstd`.

As background, I'm porting `libstd` to the Xous operating system. This is an embedded target.

In the past I've applied patches to `libunwind` in order to get it to work, however those patches are very difficult to get upstream. A recent change in llvm made C compiling difficult (https://reviews.llvm.org/D156642), and additional patches will be needed on top of Rust's hacked-up version of LLVM that adds support for SGX.

With these patches, along with an `unwinding` [backend](https://gist.github.com/xobs/0f322ff7432e117cd5ec0ad1a9e9fdf5) for the Rust `unwind` crate, I'm able to run tests and catch panics in Xous.

This patchset does two things:

1. Add support for making `core` optional, which is necessary for building as part of the tree
2. Make `text_base` optional, which is required due to the fact that Xous doesn't have this information and no platforms currently use it anyway

While it's true that (2) is an API-level change, this API is not documented in either [docs.rs](https://docs.rs/unwinding/0.1.7/unwinding/index.html) or the `examples/` directory, so I'm not sure how widely used it is.