### PR TITLE
riscv32: align stack pointer to 16-bytes

### DIFF
--- a/src/unwinder/arch/riscv32.rs
+++ b/src/unwinder/arch/riscv32.rs
@@ -176,7 +176,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
         asm!(
             "
             mv t0, sp
-            add sp, sp, -0x188
+            add sp, sp, -0x190
             sw ra, 0x180(sp)
             ",
             code!(save_gp),
@@ -186,7 +186,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             mv a0, sp
             jalr t0
             lw ra, 0x180(sp)
-            add sp, sp, 0x188
+            add sp, sp, 0x190
             ret
             ",
             options(noreturn)
@@ -197,7 +197,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
         asm!(
             "
             mv t0, sp
-            add sp, sp, -0x88
+            add sp, sp, -0x90
             sw ra, 0x80(sp)
             ",
             code!(save_gp),
@@ -206,7 +206,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             mv a0, sp
             jalr t0
             lw ra, 0x80(sp)
-            add sp, sp, 0x88
+            add sp, sp, 0x90
             ret
             ",
             options(noreturn)


### PR DESCRIPTION
Ensure RISC-V targets are aligned to 16-byte boundaries.

Even though rv32 is only 32-bits, all RISC-V stacks must be aligned to a 16-byte boundary. For discussion on this, see:

https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/21

As an example of why this is important, the `c.addi16sp` compressed instruction is only able to adjust the stack pointer by 16-byte increments.