### PR TITLE
Use intrinsics::catch_unwind instead of intrinsics::try

### DIFF
--- a/src/panicking.rs
+++ b/src/panicking.rs
@@ -39,7 +39,7 @@ pub fn catch_unwind<E: Exception, R, F: FnOnce() -> R>(f: F) -> Result<R, Option
 
     let data_ptr = &mut data as *mut _ as *mut u8;
     unsafe {
-        return if core::intrinsics::r#try(do_call::<F, R>, data_ptr, do_catch::<E>) == 0 {
+        return if core::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<E>) == 0 {
             Ok(ManuallyDrop::into_inner(data.r))
         } else {
             Err(ManuallyDrop::into_inner(data.p))


### PR DESCRIPTION
intrinsics::try has been renamed in https://github.com/rust-lang/rust/pull/121598.

Fixes #26.