### PR TITLE
Update gimli to 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,9 +18,9 @@ checksum = "01a6d58e9c3408138099a396a98fd0d0e6cfb25d723594d2ae48b5004513fd5b"
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "e2e1d97fbe9722ba9bbd0c97051c2956e726562b61f86a25a4360398a40edfc9"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [dependencies]
-gimli = { version = "0.28", default-features = false, features = ["read-core"] }
+gimli = { version = "0.30", default-features = false, features = ["read-core"] }
 libc = { version = "0.2", optional = true }
 spin = { version = "0.9.8", optional = true, default-features = false, features = ["mutex", "spin_mutex"] }
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }

--- a/src/personality.rs
+++ b/src/personality.rs
@@ -25,7 +25,7 @@ fn parse_pointer_encoding(input: &mut StaticSlice) -> gimli::Result<constants::D
     if eh_pe.is_valid_encoding() {
         Ok(eh_pe)
     } else {
-        Err(gimli::Error::UnknownPointerEncoding)
+        Err(gimli::Error::UnknownPointerEncoding(eh_pe))
     }
 }
 

--- a/src/unwinder/frame.rs
+++ b/src/unwinder/frame.rs
@@ -25,9 +25,9 @@ const fn next_value(x: usize) -> usize {
     192
 }
 
-impl<R: gimli::Reader> gimli::UnwindContextStorage<R> for StoreOnStack {
-    type Rules = [(Register, RegisterRule<R>); next_value(MAX_REG_RULES)];
-    type Stack = [UnwindTableRow<R, Self>; 2];
+impl<O: gimli::ReaderOffset> gimli::UnwindContextStorage<O> for StoreOnStack {
+    type Rules = [(Register, RegisterRule<O>); next_value(MAX_REG_RULES)];
+    type Stack = [UnwindTableRow<O, Self>; 2];
 }
 
 #[cfg(feature = "dwarf-expr")]
@@ -40,7 +40,7 @@ impl<R: gimli::Reader> gimli::EvaluationStorage<R> for StoreOnStack {
 #[derive(Debug)]
 pub struct Frame {
     fde_result: FDESearchResult,
-    row: UnwindTableRow<StaticSlice, StoreOnStack>,
+    row: UnwindTableRow<usize, StoreOnStack>,
 }
 
 impl Frame {

--- a/src/unwinder/frame.rs
+++ b/src/unwinder/frame.rs
@@ -1,5 +1,5 @@
 use gimli::{
-    BaseAddresses, CfaRule, Expression, Register, RegisterRule, UnwindContext, UnwindTableRow,
+    BaseAddresses, CfaRule, Register, RegisterRule, UnwindContext, UnwindExpression, UnwindTableRow,
 };
 #[cfg(feature = "dwarf-expr")]
 use gimli::{Evaluation, EvaluationResult, Location, Value};
@@ -79,8 +79,9 @@ impl Frame {
     fn evaluate_expression(
         &self,
         ctx: &Context,
-        expr: Expression<StaticSlice>,
+        expr: UnwindExpression<usize>,
     ) -> Result<usize, gimli::Error> {
+        let expr = expr.get(&self.fde_result.eh_frame).unwrap();
         let mut eval =
             Evaluation::<_, StoreOnStack>::new_in(expr.0, self.fde_result.fde.cie().encoding());
         let mut result = eval.evaluate()?;
@@ -120,7 +121,7 @@ impl Frame {
     fn evaluate_expression(
         &self,
         _ctx: &Context,
-        _expr: Expression<StaticSlice>,
+        _expr: UnwindExpression<usize>,
     ) -> Result<usize, gimli::Error> {
         Err(gimli::Error::UnsupportedEvaluation)
     }


### PR DESCRIPTION
I hope I fixed `evaluate_expression` correctly? My first instinct was to try to pull something from the FDE results but then the compiler said those weren't a `gimli::read::Section`, so...