### PR TITLE
Add CFI instructions for save_context

### DIFF
--- a/src/unwinder/arch/aarch64.rs
+++ b/src/unwinder/arch/aarch64.rs
@@ -64,7 +64,11 @@ macro_rules! save {
         asm!(
             "
             stp x29, x30, [sp, -16]!
+            .cfi_def_cfa_offset 16
+            .cfi_offset x29, -16
+            .cfi_offset x30, -8
             sub sp, sp, 512
+            .cfi_def_cfa_offset 528
             mov x8, x0
             mov x0, sp
             ",
@@ -82,7 +86,11 @@ macro_rules! save {
             blr x8
 
             add sp, sp, 512
+            .cfi_def_cfa_offset 16
             ldp x29, x30, [sp], 16
+            .cfi_def_cfa_offset 0
+            .cfi_restore x29
+            .cfi_restore x30
             ret
             ",
             options(noreturn)

--- a/src/unwinder/arch/riscv32.rs
+++ b/src/unwinder/arch/riscv32.rs
@@ -177,7 +177,9 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             "
             mv t0, sp
             add sp, sp, -0x190
+            .cfi_def_cfa_offset 0x190
             sw ra, 0x180(sp)
+            .cfi_offset ra, -16
             ",
             code!(save_gp),
             code!(save_fp),
@@ -187,6 +189,8 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             jalr t0
             lw ra, 0x180(sp)
             add sp, sp, 0x190
+            .cfi_def_cfa_offset 0
+            .cfi_restore ra
             ret
             ",
             options(noreturn)
@@ -198,7 +202,9 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             "
             mv t0, sp
             add sp, sp, -0x90
+            .cfi_def_cfa_offset 0x90
             sw ra, 0x80(sp)
+            .cfi_offset ra, -16
             ",
             code!(save_gp),
             "
@@ -207,6 +213,8 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             jalr t0
             lw ra, 0x80(sp)
             add sp, sp, 0x90
+            .cfi_def_cfa_offset 0
+            .cfi_restore ra
             ret
             ",
             options(noreturn)

--- a/src/unwinder/arch/riscv64.rs
+++ b/src/unwinder/arch/riscv64.rs
@@ -177,7 +177,9 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             "
             mv t0, sp
             add sp, sp, -0x210
+            .cfi_def_cfa_offset 0x210
             sd ra, 0x200(sp)
+            .cfi_offset ra, -16
             ",
             code!(save_gp),
             code!(save_fp),
@@ -187,6 +189,8 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             jalr t0
             ld ra, 0x200(sp)
             add sp, sp, 0x210
+            .cfi_def_cfa_offset 0
+            .cfi_restore ra
             ret
             ",
             options(noreturn)
@@ -198,7 +202,9 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             "
             mv t0, sp
             add sp, sp, -0x110
+            .cfi_def_cfa_offset 0x110
             sd ra, 0x100(sp)
+            .cfi_offset ra, -16
             ",
             code!(save_gp),
             "
@@ -207,6 +213,8 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             jalr t0
             ld ra, 0x100(sp)
             add sp, sp, 0x110
+            .cfi_def_cfa_offset 0
+            .cfi_restore ra
             ret
             ",
             options(noreturn)

--- a/src/unwinder/arch/x86.rs
+++ b/src/unwinder/arch/x86.rs
@@ -62,6 +62,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
         asm!(
             "
             sub esp, 52
+            .cfi_def_cfa_offset 56
 
             mov [esp + 4], ecx
             mov [esp + 8], edx
@@ -85,10 +86,13 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             mov eax, [esp + 60]
             mov ecx, esp
             push eax
+            .cfi_adjust_cfa_offset 4
             push ecx
+            .cfi_adjust_cfa_offset 4
             call [esp + 64]
 
             add esp, 60
+            .cfi_def_cfa_offset 4
             ret
             ",
             options(noreturn)

--- a/src/unwinder/arch/x86_64.rs
+++ b/src/unwinder/arch/x86_64.rs
@@ -64,6 +64,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
         asm!(
             "
             sub rsp, 0x98
+            .cfi_def_cfa_offset 0xA0
             mov [rsp + 0x18], rbx
             mov [rsp + 0x30], rbp
 
@@ -87,6 +88,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             mov rdi, rsp
             call rax
             add rsp, 0x98
+            .cfi_def_cfa_offset 8
             ret
             ",
             options(noreturn)


### PR DESCRIPTION
Tested with GDB:
- [x] x86_64
- [x] x86
- [x] aarch64
- [ ] riscv32
- [ ] riscv64

Fix #35 