### PR TITLE
naked_asm: add cfi_startproc/cfi_endproc to all platforms

### DIFF
--- a/src/unwinder/arch/aarch64.rs
+++ b/src/unwinder/arch/aarch64.rs
@@ -63,6 +63,7 @@ macro_rules! save {
     (gp$(, $fp:ident)?) => {
         // No need to save caller-saved registers here.
         core::arch::naked_asm!(
+            maybe_cfi!(".cfi_startproc"),
             "stp x29, x30, [sp, -16]!",
             maybe_cfi!("
             .cfi_def_cfa_offset 16
@@ -98,6 +99,7 @@ macro_rules! save {
             .cfi_restore x30
             "),
             "ret",
+            maybe_cfi!(".cfi_endproc"),
         );
     };
     (maybesavefp(fp)) => {

--- a/src/unwinder/arch/riscv64.rs
+++ b/src/unwinder/arch/riscv64.rs
@@ -82,7 +82,10 @@ macro_rules! code {
         "
     };
     (save_fp) => {
+        // arch option manipulation needed due to LLVM/Rust bug, see rust-lang/rust#80608
         "
+        .option push
+        .option arch, +d
         fsd fs0, 0x140(sp)
         fsd fs1, 0x148(sp)
         fsd fs2, 0x190(sp)
@@ -95,6 +98,7 @@ macro_rules! code {
         fsd fs9, 0x1C8(sp)
         fsd fs10, 0x1D0(sp)
         fsd fs11, 0x1D8(sp)
+        .option pop
         "
     };
     (restore_gp) => {
@@ -175,6 +179,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
     #[cfg(target_feature = "d")]
     unsafe {
         core::arch::naked_asm!(
+            maybe_cfi!(".cfi_startproc"),
             "
             mv t0, sp
             add sp, sp, -0x210
@@ -194,11 +199,13 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             maybe_cfi!(".cfi_def_cfa_offset 0"),
             maybe_cfi!(".cfi_restore ra"),
             "ret",
+            maybe_cfi!(".cfi_endproc"),
         );
     }
     #[cfg(not(target_feature = "d"))]
     unsafe {
         core::arch::naked_asm!(
+            maybe_cfi!(".cfi_startproc"),
             "
             mv t0, sp
             add sp, sp, -0x110
@@ -217,6 +224,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             maybe_cfi!(".cfi_def_cfa_offset 0"),
             maybe_cfi!(".cfi_restore ra"),
             "ret",
+            maybe_cfi!(".cfi_endproc"),
         );
     }
 }

--- a/src/unwinder/arch/x86.rs
+++ b/src/unwinder/arch/x86.rs
@@ -61,6 +61,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
     // No need to save caller-saved registers here.
     unsafe {
         core::arch::naked_asm!(
+            maybe_cfi!(".cfi_startproc"),
             "sub esp, 52",
             maybe_cfi!(".cfi_def_cfa_offset 56"),
             "
@@ -97,6 +98,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             ",
             maybe_cfi!(".cfi_def_cfa_offset 4"),
             "ret",
+            maybe_cfi!(".cfi_endproc"),
         );
     }
 }

--- a/src/unwinder/arch/x86_64.rs
+++ b/src/unwinder/arch/x86_64.rs
@@ -63,6 +63,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
     // No need to save caller-saved registers here.
     unsafe {
         core::arch::naked_asm!(
+            maybe_cfi!(".cfi_startproc"),
             "sub rsp, 0x98",
             maybe_cfi!(".cfi_def_cfa_offset 0xA0"),
             "
@@ -91,7 +92,8 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             add rsp, 0x98
             ",
             maybe_cfi!(".cfi_def_cfa_offset 8"),
-            "ret"
+            "ret",
+            maybe_cfi!(".cfi_endproc"),
         );
     }
 }


### PR DESCRIPTION
Since 2024-12-12 the Rust compiler now requires all naked ASM functions to include `.cfi_startproc` and `.cfi_endproc`. Without these directives, the build will fail.

The x86_64 target already had these directives, so it was unaffected by this change.

Add these directives to all other supported platforms.

This closes #41.