### PR TITLE
Upgrade `gimli` to 0.32.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,11 +18,10 @@ checksum = "7925a77545f37a18e152a4aeaeb9a220309022067cafcfa2ecebe9ec55d36ccb"
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "93563d740bc9ef04104f9ed6f86f1e3275c2cdafb95664e26584b9ca807a8ffe"
 dependencies = [
- "compiler_builtins",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [dependencies]
-gimli = { version = "0.31", default-features = false, features = ["read-core"] }
+gimli = { version = "0.32", default-features = false, features = ["read-core"] }
 libc = { version = "0.2", optional = true }
 spin = { version = "0.9.8", optional = true, default-features = false, features = ["mutex", "spin_mutex"] }
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }


### PR DESCRIPTION
The breaking change here involves API for `read::Dwarf`, `read::CallFrameInstruction`, and `write::LineProgram`, none of which are used in this crate. Making this change will allow `std` to upgrade to a version of `gimli` that drops the `compiler_builtins` dependency, which is needed for [1].

Changelog: https://github.com/gimli-rs/gimli/blob/master/CHANGELOG.md#0320

[1]: https://github.com/rust-lang/rust/issues/142265