### PR TITLE
Remove the `compiler_builtins` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,12 +11,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compiler_builtins"
-version = "0.1.139"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7925a77545f37a18e152a4aeaeb9a220309022067cafcfa2ecebe9ec55d36ccb"
-
-[[package]]
 name = "gimli"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,7 +71,6 @@ dependencies = [
 name = "unwinding"
 version = "0.2.7"
 dependencies = [
- "compiler_builtins",
  "gimli",
  "libc",
  "rustc-std-workspace-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ gimli = { version = "0.32", default-features = false, features = ["read-core"] }
 libc = { version = "0.2", optional = true }
 spin = { version = "0.9.8", optional = true, default-features = false, features = ["mutex", "spin_mutex"] }
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
-compiler_builtins = { version = "0.1.2", optional = true }
 
 [features]
 alloc = []
@@ -45,9 +44,7 @@ panic-handler = ["print", "panic"]
 panic-handler-dummy = []
 system-alloc = []
 default = ["unwinder", "dwarf-expr", "hide-trace", "fde-phdr-dl", "fde-registry"]
-rustc-dep-of-std = ["core", "gimli/rustc-dep-of-std", "compiler_builtins"]
-compiler_builtins = ["dep:compiler_builtins"]
-core = ["dep:core"]
+rustc-dep-of-std = ["dep:core", "gimli/rustc-dep-of-std"]
 libc = ["dep:libc"]
 spin = ["dep:spin"]
 


### PR DESCRIPTION
Since [1] the crates.io version of `compiler-builtins` is no longer needed as part of `rustc-dep-of-std`, so remove it here.

[1]: https://github.com/rust-lang/rust/issues/142265