### PR TITLE
Add arch support for LoongArch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - aarch64-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu
           - riscv32gc-unknown-linux-gnu
+          - loongarch64-unknown-linux-gnu
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library serves two purposes:
 1. Provide a pure Rust alternative to libgcc_eh or libunwind.
 2. Provide easier unwinding support for `#![no_std]` targets.
 
-Currently supports x86_64, x86, RV64, RV32 and AArch64.
+Currently supports x86_64, x86, RV64, RV32, AArch64, and LoongArch64.
 
 ## Unwinder
 

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -70,11 +70,30 @@ mod aarch64 {
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::*;
 
+#[cfg(target_arch = "loongarch64")]
+mod loongarch64 {
+    use gimli::{LoongArch, Register};
+
+    pub struct Arch;
+
+    #[allow(unused)]
+    impl Arch {
+        pub const SP: Register = LoongArch::SP;
+        pub const RA: Register = LoongArch::RA;
+
+        pub const UNWIND_DATA_REG: (Register, Register) = (LoongArch::A0, LoongArch::A1);
+        pub const UNWIND_PRIVATE_DATA_SIZE: usize = 2;
+    }
+}
+#[cfg(target_arch = "loongarch64")]
+pub use loongarch64::*;
+
 #[cfg(not(any(
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
     target_arch = "riscv32",
-    target_arch = "aarch64"
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
 )))]
 compile_error!("Current architecture is not supported");

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -3,12 +3,14 @@ use gimli::{LoongArch, Register};
 
 use super::maybe_cfi;
 
+// LoongArch64's DWARF_FRAME_REGISTERS in GCC is 74
 pub const MAX_REG_RULES: usize = 74;
 
 #[repr(C)]
 #[derive(Clone, Default)]
 pub struct Context {
     pub gp: [usize; 32],
+    #[cfg(target_feature = "d")]
     pub fp: [usize; 32],
 }
 
@@ -21,6 +23,7 @@ impl fmt::Debug for Context {
                 &format_args!("{:#x}", self.gp[i]),
             );
         }
+        #[cfg(target_feature = "d")]
         for i in 0..=31 {
             fmt.field(
                 LoongArch::register_name(Register((i + 32) as _)).unwrap(),
@@ -37,6 +40,7 @@ impl ops::Index<Register> for Context {
     fn index(&self, reg: Register) -> &usize {
         match reg {
             Register(0..=31) => &self.gp[reg.0 as usize],
+            #[cfg(target_feature = "d")]
             Register(32..=63) => &self.fp[(reg.0 - 32) as usize],
             _ => unimplemented!(),
         }
@@ -47,6 +51,7 @@ impl ops::IndexMut<gimli::Register> for Context {
     fn index_mut(&mut self, reg: Register) -> &mut usize {
         match reg {
             Register(0..=31) => &mut self.gp[reg.0 as usize],
+            #[cfg(target_feature = "d")]
             Register(32..=63) => &mut self.fp[(reg.0 - 32) as usize],
             _ => unimplemented!(),
         }
@@ -58,43 +63,40 @@ macro_rules! save_regs {
         core::arch::naked_asm!(
             maybe_cfi!(".cfi_startproc"),
             "
-            move $r12, $r3
-            addi.d $r3, $r3, -0x210
+            move $t0, $sp
+            addi.d $sp, $sp, -0x210
             ",
             maybe_cfi!(".cfi_def_cfa_offset 0x210"),
             "
-            st.d $r1, $r3, 0x200
+            st.d $ra, $sp, 0x200
             ",
             maybe_cfi!(".cfi_offset 1, -16"), // ra
             "
-            st.d $r0, $r3, 0x0 // zero
-            st.d $r1, $r3, 0x8 // ra
-            st.d $r2, $r3, 0x10 // tp
-            // sp is saved later
-            st.d $r21, $r3, 0xa8 // reserved
-            st.d $r22, $r3, 0xb0 // fp
-            st.d $r23, $r3, 0xb8 // s0
-            st.d $r24, $r3, 0xc0 // s1
-            st.d $r25, $r3, 0xc8 // s2
-            st.d $r26, $r3, 0xd0 // s3
-            st.d $r27, $r3, 0xd8 // s4
-            st.d $r28, $r3, 0xe0 // s5
-            st.d $r29, $r3, 0xe8 // s6
-            st.d $r30, $r3, 0xf0 // s7
-            st.d $r31, $r3, 0xf8 // s8
+            st.d $zero, $sp, 0x0
+            st.d $ra, $sp, 0x8
+            st.d $tp, $sp, 0x10
+            st.d $t0, $sp, 0x18
+            st.d $r21, $sp, 0xa8 // reserved
+            st.d $fp, $sp, 0xb0
+            st.d $s0, $sp, 0xb8
+            st.d $s1, $sp, 0xc0
+            st.d $s2, $sp, 0xc8
+            st.d $s3, $sp, 0xd0
+            st.d $s4, $sp, 0xd8
+            st.d $s5, $sp, 0xe0
+            st.d $s6, $sp, 0xe8
+            st.d $s7, $sp, 0xf0
+            st.d $s8, $sp, 0xf8
             ",
             save_regs!(maybe_save_fp($($fp)?)),
             "
-            move $r12, $r4
-            move $r4, $r3 // argument a0 pointing the ctx base
+            move $t0, $a0
+            move $a0, $sp
 
-            addi.d $r13, $r3, 0x210
-            st.d $r13, $r3, 0x18 // save sp
+            jirl $ra, $t0, 0
 
-            jirl $r1, $r12, 0 // call f
-
-            ld.d $r1, $r3, 0x200
-            addi.d $r3, $r3, 0x210 // restore ra and sp
+            ld.d $ra, $sp, 0x200
+            addi.d $sp, $sp, 0x210
             ",
             maybe_cfi!(".cfi_def_cfa_offset 0"),
             maybe_cfi!(".cfi_restore 1"), // ra
@@ -106,14 +108,14 @@ macro_rules! save_regs {
     };
     (maybe_save_fp(fp)) => {
         "
-        fst.d $f24, $r3, 0x1c0 // fs0
-        fst.d $f25, $r3, 0x1c8 // fs1
-        fst.d $f26, $r3, 0x1d0 // fs2
-        fst.d $f27, $r3, 0x1d8 // fs3
-        fst.d $f28, $r3, 0x1e0 // fs4
-        fst.d $f29, $r3, 0x1e8 // fs5
-        fst.d $f30, $r3, 0x1f0 // fs6
-        fst.d $f31, $r3, 0x1f8 // fs7
+        fst.d $fs0, $sp, 0x1c0
+        fst.d $fs1, $sp, 0x1c8
+        fst.d $fs2, $sp, 0x1d0
+        fst.d $fs3, $sp, 0x1d8
+        fst.d $fs4, $sp, 0x1e0
+        fst.d $fs5, $sp, 0x1e8
+        fst.d $fs6, $sp, 0x1f0
+        fst.d $fs7, $sp, 0x1f8
         "
     };
     (maybe_save_fp()) => {
@@ -126,80 +128,79 @@ macro_rules! restore_regs {
         core::arch::asm!(
             restore_regs!(maybe_restore_fp($($fp)?)),
             "
-            ld.d $r1, $r4, 0x8 // ra
-            ld.d $r2, $r4, 0x10 // tp
-            ld.d $r3, $r4, 0x18 // sp
-            // r4(a0) is restored later
-            ld.d $r5, $r4, 0x28 // a1
-            ld.d $r6, $r4, 0x30 // a2
-            ld.d $r7, $r4, 0x38 // a3
-            ld.d $r8, $r4, 0x40 // a4
-            ld.d $r9, $r4, 0x48 // a5
-            ld.d $r10, $r4, 0x50 // a6
-            ld.d $r11, $r4, 0x58 // a7
-            ld.d $r12, $r4, 0x60 // t0
-            ld.d $r13, $r4, 0x68 // t1
-            ld.d $r14, $r4, 0x70 // t2
-            ld.d $r15, $r4, 0x78 // t3
-            ld.d $r16, $r4, 0x80 // t4
-            ld.d $r17, $r4, 0x88 // t5
-            ld.d $r18, $r4, 0x90 // t6
-            ld.d $r19, $r4, 0x98 // t7
-            ld.d $r20, $r4, 0xa0 // t8
-            ld.d $r21, $r4, 0xa8 // reserved
-            ld.d $r22, $r4, 0xb0 // fp
-            ld.d $r23, $r4, 0xb8 // s0
-            ld.d $r24, $r4, 0xc0 // s1
-            ld.d $r25, $r4, 0xc8 // s2
-            ld.d $r26, $r4, 0xd0 // s3
-            ld.d $r27, $r4, 0xd8 // s4
-            ld.d $r28, $r4, 0xe0 // s5
-            ld.d $r29, $r4, 0xe8 // s6
-            ld.d $r30, $r4, 0xf0 // s7
-            ld.d $r31, $r4, 0xf8 // s8
+            ld.d $ra, $a0, 0x8
+            ld.d $tp, $a0, 0x10
+            ld.d $sp, $a0, 0x18
+            ld.d $a1, $a0, 0x28
+            ld.d $a2, $a0, 0x30
+            ld.d $a3, $a0, 0x38
+            ld.d $a4, $a0, 0x40
+            ld.d $a5, $a0, 0x48
+            ld.d $a6, $a0, 0x50
+            ld.d $a7, $a0, 0x58
+            ld.d $t0, $a0, 0x60
+            ld.d $t1, $a0, 0x68
+            ld.d $t2, $a0, 0x70
+            ld.d $t3, $a0, 0x78
+            ld.d $t4, $a0, 0x80
+            ld.d $t5, $a0, 0x88
+            ld.d $t6, $a0, 0x90
+            ld.d $t7, $a0, 0x98
+            ld.d $t8, $a0, 0xa0
+            ld.d $r21, $a0, 0xa8 // reserved
+            ld.d $fp, $a0, 0xb0
+            ld.d $s0, $a0, 0xb8
+            ld.d $s1, $a0, 0xc0
+            ld.d $s2, $a0, 0xc8
+            ld.d $s3, $a0, 0xd0
+            ld.d $s4, $a0, 0xd8
+            ld.d $s5, $a0, 0xe0
+            ld.d $s6, $a0, 0xe8
+            ld.d $s7, $a0, 0xf0
+            ld.d $s8, $a0, 0xf8
             ",
             "
-            ld.d $r4, $r4, 0x20
+            ld.d $a0, $a0, 0x20
             ret
             ",
-            in("$r4") $ctx,
+            in("$a0") $ctx,
             options(noreturn)
         )
     };
     (maybe_restore_fp(fp)) => {
         "
-        fld.d $f0, $r4, 0x100 // fa0
-        fld.d $f1, $r4, 0x108 // fa1
-        fld.d $f2, $r4, 0x110 // fa2
-        fld.d $f3, $r4, 0x118 // fa3
-        fld.d $f4, $r4, 0x120 // fa4
-        fld.d $f5, $r4, 0x128 // fa5
-        fld.d $f6, $r4, 0x130 // fa6
-        fld.d $f7, $r4, 0x138 // fa7
-        fld.d $f8, $r4, 0x140 // ft0
-        fld.d $f9, $r4, 0x148 // ft1
-        fld.d $f10, $r4, 0x150 // ft2
-        fld.d $f11, $r4, 0x158 // ft3
-        fld.d $f12, $r4, 0x160 // ft4
-        fld.d $f13, $r4, 0x168 // ft5
-        fld.d $f14, $r4, 0x170 // ft6
-        fld.d $f15, $r4, 0x178 // ft7
-        fld.d $f16, $r4, 0x180 // ft8
-        fld.d $f17, $r4, 0x188 // ft9
-        fld.d $f18, $r4, 0x190 // ft10
-        fld.d $f19, $r4, 0x198 // ft11
-        fld.d $f20, $r4, 0x1a0 // ft12
-        fld.d $f21, $r4, 0x1a8 // ft13
-        fld.d $f22, $r4, 0x1b0 // ft14
-        fld.d $f23, $r4, 0x1b8 // ft15
-        fld.d $f24, $r4, 0x1c0 // fs0
-        fld.d $f25, $r4, 0x1c8 // fs1
-        fld.d $f26, $r4, 0x1d0 // fs2
-        fld.d $f27, $r4, 0x1d8 // fs3
-        fld.d $f28, $r4, 0x1e0 // fs4
-        fld.d $f29, $r4, 0x1e8 // fs5
-        fld.d $f30, $r4, 0x1f0 // fs6
-        fld.d $f31, $r4, 0x1f8 // fs7
+        fld.d $fa0, $a0, 0x100
+        fld.d $fa1, $a0, 0x108
+        fld.d $fa2, $a0, 0x110
+        fld.d $fa3, $a0, 0x118
+        fld.d $fa4, $a0, 0x120
+        fld.d $fa5, $a0, 0x128
+        fld.d $fa6, $a0, 0x130
+        fld.d $fa7, $a0, 0x138
+        fld.d $ft0, $a0, 0x140
+        fld.d $ft1, $a0, 0x148
+        fld.d $ft2, $a0, 0x150
+        fld.d $ft3, $a0, 0x158
+        fld.d $ft4, $a0, 0x160
+        fld.d $ft5, $a0, 0x168
+        fld.d $ft6, $a0, 0x170
+        fld.d $ft7, $a0, 0x178
+        fld.d $ft8, $a0, 0x180
+        fld.d $ft9, $a0, 0x188
+        fld.d $ft10, $a0, 0x190
+        fld.d $ft11, $a0, 0x198
+        fld.d $ft12, $a0, 0x1a0
+        fld.d $ft13, $a0, 0x1a8
+        fld.d $ft14, $a0, 0x1b0
+        fld.d $ft15, $a0, 0x1b8
+        fld.d $fs0, $a0, 0x1c0
+        fld.d $fs1, $a0, 0x1c8
+        fld.d $fs2, $a0, 0x1d0
+        fld.d $fs3, $a0, 0x1d8
+        fld.d $fs4, $a0, 0x1e0
+        fld.d $fs5, $a0, 0x1e8
+        fld.d $fs6, $a0, 0x1f0
+        fld.d $fs7, $a0, 0x1f8
         "
     };
     (maybe_restore_fp()) => {

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -3,8 +3,7 @@ use gimli::{LoongArch, Register};
 
 use super::maybe_cfi;
 
-// https://github.com/loongson/la-abi-specs/blob/release/ladwarf.adoc
-pub const MAX_REG_RULES: usize = 65;
+pub const MAX_REG_RULES: usize = 74;
 
 #[repr(C)]
 #[derive(Clone, Default)]

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -4,7 +4,8 @@ use gimli::{LoongArch, Register};
 
 use super::maybe_cfi;
 
-pub const MAX_REG_RULES: usize = 0; // TODO: find the GCC's MAX_REG_RULES for loongarch64
+// https://github.com/loongson/la-abi-specs/blob/release/ladwarf.adoc
+pub const MAX_REG_RULES: usize = 65;
 
 #[repr(C)]
 #[derive(Clone, Default)]
@@ -57,16 +58,61 @@ impl ops::IndexMut<gimli::Register> for Context {
 }
 
 macro_rules! save {
-    (gp$(, $fp:ident)?) => {
-        core::arch::naked_asm!("addi.d $r3, $r3, -16", "ret",);
+    (gp, fp) => {
+        core::arch::naked_asm!(
+            maybe_cfi!(".cfi_startproc"),
+            "addi.d $r3, $r3, -16",
+            maybe_cfi!(".cfi_def_cfa_offset 16"),
+            "st.d $r1, $r3, 0",
+            maybe_cfi!(".cfi_offset $r1, 0"),
+            "st.d $r22, $r3, 8",
+            maybe_cfi!(".cfi_offset $r22, 8"),
+            "addi.d $r3, $r3, -512",
+            maybe_cfi!(".cfi_def_cfa_offset 528"),
+            "
+            move $r8, $r4
+            move $r4, $r3
+            ",
+            save!(savefp),
+            "
+            st.d $r23, $r3, 0x18
+            st.d $r24, $r3, 0x20
+            st.d $r25, $r3, 0x28
+            st.d $r26, $r3, 0x30
+            st.d $r27, $r3, 0x38
+            st.d $r28, $r3, 0x40
+            st.d $r29, $r3, 0x48
+            st.d $r30, $r3, 0x50
+            st.d $r31, $r3, 0x58
+            addi.d $r2, $r3, 528
+            st.d $r2, $r3, 0x60
+
+            jirl $r1, $r8, 0
+
+            addi.d $r3, $r3, 512
+            ",
+            maybe_cfi!(".cfi_def_cfa_offset 16"),
+            "ld.d $r1, $r3, 0",
+            maybe_cfi!(".cfi_restore $r1"),
+            "ld.d $r22, $r3, 8",
+            maybe_cfi!(".cfi_restore $r22"),
+            "addi.d $r3, $r3, 16",
+            maybe_cfi!(".cfi_def_cfa_offset 0"),
+            "ret",
+            maybe_cfi!(".cfi_endproc"),
+        );
     };
-    (maybesavefp(fp)) => {
+    (savefp) => {
         "
-        fst.d $f24, ($r3, 0x140)
+        fst.d $f24, $r3, 0x140
+        fst.d $f25, $r3, 0x148
+        fst.d $f26, $r3, 0x150
+        fst.d $f27, $r3, 0x158
+        fst.d $f28, $r3, 0x160
+        fst.d $f29, $r3, 0x168
+        fst.d $f30, $r3, 0x170
+        fst.d $f31, $r3, 0x178
         "
-    };
-    (maybesavefp()) => {
-        ""
     };
 }
 
@@ -78,18 +124,83 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
 }
 
 macro_rules! restore {
-    ($ctx:expr, gp$(, $fp:ident)?) => {
+    ($ctx:expr, gp, fp) => {
         core::arch::asm!(
-        "addi.d $r3, $r3, -16",
-        in("$r1") $ctx,
-        options(noreturn));
+            restore!(restore),
+            "
+            ld.d $r2, $r4, 0x10
+            ld.d $r5, $r4, 0x18
+            ld.d $r6, $r4, 0x20
+            ld.d $r7, $r4, 0x28
+            ld.d $r8, $r4, 0x30
+            ld.d $r9, $r4, 0x38
+            ld.d $r10, $r4, 0x40
+            ld.d $r11, $r4, 0x48
+            ld.d $r12, $r4, 0x50
+            ld.d $r13, $r4, 0x58
+            ld.d $r14, $r4, 0x60
+            ld.d $r15, $r4, 0x68
+            ld.d $r16, $r4, 0x70
+            ld.d $r17, $r4, 0x78
+            ld.d $r18, $r4, 0x80
+            ld.d $r19, $r4, 0x88
+            ld.d $r20, $r4, 0x90
+            ld.d $r21, $r4, 0x98
+            ld.d $r22, $r4, 0xA0
+            ld.d $r23, $r4, 0xA8
+            ld.d $r24, $r4, 0xB0
+            ld.d $r25, $r4, 0xB8
+            ld.d $r26, $r4, 0xC0
+            ld.d $r27, $r4, 0xC8
+            ld.d $r28, $r4, 0xD0
+            ld.d $r29, $r4, 0xD8
+            ld.d $r30, $r4, 0xE0
+            ld.d $r31, $r4, 0xE8
+            ld.d $r1, $r4, 0xF0
+
+            ld.d $r3, $r4, 0x00
+            ld.d $r4, $r4, 0x08
+            ret
+            ",
+            in("$r4") $ctx,
+            options(noreturn)
+        );
     };
-    (mayberestore(fp)) => {
+    (restore) => {
         "
+        fld.d $f0, $r4, 0x100
+        fld.d $f1, $r4, 0x108
+        fld.d $f2, $r4, 0x110
+        fld.d $f3, $r4, 0x118
+        fld.d $f4, $r4, 0x120
+        fld.d $f5, $r4, 0x128
+        fld.d $f6, $r4, 0x130
+        fld.d $f7, $r4, 0x138
+        fld.d $f8, $r4, 0x140
+        fld.d $f9, $r4, 0x148
+        fld.d $f10, $r4, 0x150
+        fld.d $f11, $r4, 0x158
+        fld.d $f12, $r4, 0x160
+        fld.d $f13, $r4, 0x168
+        fld.d $f14, $r4, 0x170
+        fld.d $f15, $r4, 0x178
+        fld.d $f16, $r4, 0x180
+        fld.d $f17, $r4, 0x188
+        fld.d $f18, $r4, 0x190
+        fld.d $f19, $r4, 0x198
+        fld.d $f20, $r4, 0x1A0
+        fld.d $f21, $r4, 0x1A8
+        fld.d $f22, $r4, 0x1B0
+        fld.d $f23, $r4, 0x1B8
+        fld.d $f24, $r4, 0x1C0
+        fld.d $f25, $r4, 0x1C8
+        fld.d $f26, $r4, 0x1D0
+        fld.d $f27, $r4, 0x1D8
+        fld.d $f28, $r4, 0x1E0
+        fld.d $f29, $r4, 0x1E8
+        fld.d $f30, $r4, 0x1F0
+        fld.d $f31, $r4, 0x1F8
         "
-    };
-    (mayberestore()) => {
-        ""
     };
 }
 

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -10,7 +10,6 @@ pub const MAX_REG_RULES: usize = 65;
 #[derive(Clone, Default)]
 pub struct Context {
     pub gp: [usize; 32],
-    // sp is gp[3]
     pub fp: [usize; 32],
 }
 
@@ -23,7 +22,6 @@ impl fmt::Debug for Context {
                 &format_args!("{:#x}", self.gp[i]),
             );
         }
-        fmt.field("sp", &self.gp[3]);
         for i in 0..=31 {
             fmt.field(
                 LoongArch::register_name(Register((i + 32) as _)).unwrap(),
@@ -69,7 +67,23 @@ macro_rules! save_regs {
             st.d $r1, $r3, 0x200
             ",
             maybe_cfi!(".cfi_offset 1, -16"), // ra
-            helper!(save_gp),
+            "
+            st.d $r0, $r3, 0x0 // zero
+            st.d $r1, $r3, 0x8 // ra
+            st.d $r2, $r3, 0x10 // tp
+            // sp is saved later
+            st.d $r21, $r3, 0xa8 // reserved
+            st.d $r22, $r3, 0xb0 // fp
+            st.d $r23, $r3, 0xb8 // s0
+            st.d $r24, $r3, 0xc0 // s1
+            st.d $r25, $r3, 0xc8 // s2
+            st.d $r26, $r3, 0xd0 // s3
+            st.d $r27, $r3, 0xd8 // s4
+            st.d $r28, $r3, 0xe0 // s5
+            st.d $r29, $r3, 0xe8 // s6
+            st.d $r30, $r3, 0xf0 // s7
+            st.d $r31, $r3, 0xf8 // s8
+            ",
             save_regs!(maybe_save_fp($($fp)?)),
             "
             move $r12, $r4
@@ -92,56 +106,6 @@ macro_rules! save_regs {
         )
     };
     (maybe_save_fp(fp)) => {
-        helper!(save_fp)
-    };
-    (maybe_save_fp()) => {
-        ""
-    };
-}
-
-macro_rules! restore_regs {
-    ($ctx:expr, gp$(, $fp:ident)?) => {
-        core::arch::asm!(
-            restore_regs!(maybe_restore_fp($($fp)?)),
-            helper!(restore_gp),
-            "
-            ld.d $r4, $r4, 0x20
-            ret
-            ",
-            in("$r4") $ctx,
-            options(noreturn)
-        )
-    };
-    (maybe_restore_fp(fp)) => {
-        helper!(restore_fp)
-    };
-    (maybe_restore_fp()) => {
-        ""
-    };
-}
-
-macro_rules! helper {
-    // see https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html for ABI conventions
-    (save_gp) => {
-        "
-        st.d $r0, $r3, 0x0 // zero
-        st.d $r1, $r3, 0x8 // ra
-        st.d $r2, $r3, 0x10 // tp
-        // sp is saved later
-        st.d $r21, $r3, 0xa8 // reserved
-        st.d $r22, $r3, 0xb0 // fp
-        st.d $r23, $r3, 0xb8 // s0
-        st.d $r24, $r3, 0xc0 // s1
-        st.d $r25, $r3, 0xc8 // s2
-        st.d $r26, $r3, 0xd0 // s3
-        st.d $r27, $r3, 0xd8 // s4
-        st.d $r28, $r3, 0xe0 // s5
-        st.d $r29, $r3, 0xe8 // s6
-        st.d $r30, $r3, 0xf0 // s7
-        st.d $r31, $r3, 0xf8 // s8
-        "
-    };
-    (save_fp) => {
         "
         fst.d $f24, $r3, 0x1c0 // fs0
         fst.d $f25, $r3, 0x1c8 // fs1
@@ -153,42 +117,57 @@ macro_rules! helper {
         fst.d $f31, $r3, 0x1f8 // fs7
         "
     };
-    (restore_gp) => {
-        "
-        ld.d $r1, $r4, 0x8 // ra
-        ld.d $r2, $r4, 0x10 // tp
-        ld.d $r3, $r4, 0x18 // sp
-        // r4(a0) is restored later
-        ld.d $r5, $r4, 0x28 // a1
-        ld.d $r6, $r4, 0x30 // a2
-        ld.d $r7, $r4, 0x38 // a3
-        ld.d $r8, $r4, 0x40 // a4
-        ld.d $r9, $r4, 0x48 // a5
-        ld.d $r10, $r4, 0x50 // a6
-        ld.d $r11, $r4, 0x58 // a7
-        ld.d $r12, $r4, 0x60 // t0
-        ld.d $r13, $r4, 0x68 // t1
-        ld.d $r14, $r4, 0x70 // t2
-        ld.d $r15, $r4, 0x78 // t3
-        ld.d $r16, $r4, 0x80 // t4
-        ld.d $r17, $r4, 0x88 // t5
-        ld.d $r18, $r4, 0x90 // t6
-        ld.d $r19, $r4, 0x98 // t7
-        ld.d $r20, $r4, 0xa0 // t8
-        ld.d $r21, $r4, 0xa8 // reserved
-        ld.d $r22, $r4, 0xb0 // fp
-        ld.d $r23, $r4, 0xb8 // s0
-        ld.d $r24, $r4, 0xc0 // s1
-        ld.d $r25, $r4, 0xc8 // s2
-        ld.d $r26, $r4, 0xd0 // s3
-        ld.d $r27, $r4, 0xd8 // s4
-        ld.d $r28, $r4, 0xe0 // s5
-        ld.d $r29, $r4, 0xe8 // s6
-        ld.d $r30, $r4, 0xf0 // s7
-        ld.d $r31, $r4, 0xf8 // s8
-        "
+    (maybe_save_fp()) => {
+        ""
     };
-    (restore_fp) => {
+}
+
+macro_rules! restore_regs {
+    ($ctx:expr, gp$(, $fp:ident)?) => {
+        core::arch::asm!(
+            restore_regs!(maybe_restore_fp($($fp)?)),
+            "
+            ld.d $r1, $r4, 0x8 // ra
+            ld.d $r2, $r4, 0x10 // tp
+            ld.d $r3, $r4, 0x18 // sp
+            // r4(a0) is restored later
+            ld.d $r5, $r4, 0x28 // a1
+            ld.d $r6, $r4, 0x30 // a2
+            ld.d $r7, $r4, 0x38 // a3
+            ld.d $r8, $r4, 0x40 // a4
+            ld.d $r9, $r4, 0x48 // a5
+            ld.d $r10, $r4, 0x50 // a6
+            ld.d $r11, $r4, 0x58 // a7
+            ld.d $r12, $r4, 0x60 // t0
+            ld.d $r13, $r4, 0x68 // t1
+            ld.d $r14, $r4, 0x70 // t2
+            ld.d $r15, $r4, 0x78 // t3
+            ld.d $r16, $r4, 0x80 // t4
+            ld.d $r17, $r4, 0x88 // t5
+            ld.d $r18, $r4, 0x90 // t6
+            ld.d $r19, $r4, 0x98 // t7
+            ld.d $r20, $r4, 0xa0 // t8
+            ld.d $r21, $r4, 0xa8 // reserved
+            ld.d $r22, $r4, 0xb0 // fp
+            ld.d $r23, $r4, 0xb8 // s0
+            ld.d $r24, $r4, 0xc0 // s1
+            ld.d $r25, $r4, 0xc8 // s2
+            ld.d $r26, $r4, 0xd0 // s3
+            ld.d $r27, $r4, 0xd8 // s4
+            ld.d $r28, $r4, 0xe0 // s5
+            ld.d $r29, $r4, 0xe8 // s6
+            ld.d $r30, $r4, 0xf0 // s7
+            ld.d $r31, $r4, 0xf8 // s8
+            ",
+            "
+            ld.d $r4, $r4, 0x20
+            ret
+            ",
+            in("$r4") $ctx,
+            options(noreturn)
+        )
+    };
+    (maybe_restore_fp(fp)) => {
         "
         fld.d $f0, $r4, 0x100 // fa0
         fld.d $f1, $r4, 0x108 // fa1
@@ -223,6 +202,9 @@ macro_rules! helper {
         fld.d $f30, $r4, 0x1f0 // fs6
         fld.d $f31, $r4, 0x1f8 // fs7
         "
+    };
+    (maybe_restore_fp()) => {
+        ""
     };
 }
 

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -162,6 +162,7 @@ macro_rules! ctx_helper {
 
 #[unsafe(naked)]
 pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), ptr: *mut ()) {
+    #[allow(unused_unsafe)]
     unsafe {
         core::arch::naked_asm!(
             maybe_cfi!(".cfi_startproc"),

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-use core::ops;
+use core::{fmt, ops};
 use gimli::{LoongArch, Register};
 
 use super::maybe_cfi;
@@ -61,9 +60,11 @@ macro_rules! ctx_helper {
     // see https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html for ABI conventions
     (save_gp) => {
         "
+        st.d $r0, $r3, 0x0 // zero
         st.d $r1, $r3, 0x8 // ra
         st.d $r2, $r3, 0x10 // tp
         // sp is saved later
+        st.d $r21, $r3, 0xa8 // reserved
         st.d $r22, $r3, 0xb0 // fp
         st.d $r23, $r3, 0xb8 // s0
         st.d $r24, $r3, 0xc0 // s1

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -1,4 +1,5 @@
-use core::{fmt, ops};
+use core::fmt;
+use core::ops;
 use gimli::{LoongArch, Register};
 
 use super::maybe_cfi;
@@ -6,6 +7,9 @@ use super::maybe_cfi;
 // LoongArch64's DWARF_FRAME_REGISTERS in GCC is 74
 pub const MAX_REG_RULES: usize = 74;
 
+// https://doc.rust-lang.org/beta/rustc/platform-support/loongarch-none.html
+// https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
+// loongarch64: Rust supports only LP64D and LP64S
 #[repr(C)]
 #[derive(Clone, Default)]
 pub struct Context {
@@ -20,14 +24,14 @@ impl fmt::Debug for Context {
         for i in 0..=31 {
             fmt.field(
                 LoongArch::register_name(Register(i as _)).unwrap(),
-                &format_args!("{:#x}", self.gp[i]),
+                &self.gp[i],
             );
         }
         #[cfg(target_feature = "d")]
         for i in 0..=31 {
             fmt.field(
                 LoongArch::register_name(Register((i + 32) as _)).unwrap(),
-                &format_args!("{:#x}", self.fp[i]),
+                &self.fp[i],
             );
         }
         fmt.finish()
@@ -58,55 +62,27 @@ impl ops::IndexMut<gimli::Register> for Context {
     }
 }
 
-macro_rules! save_regs {
-    (gp$(, $fp:ident)?) => {
-        core::arch::naked_asm!(
-            maybe_cfi!(".cfi_startproc"),
-            "
-            move $t0, $sp
-            addi.d $sp, $sp, -0x210
-            ",
-            maybe_cfi!(".cfi_def_cfa_offset 0x210"),
-            "
-            st.d $ra, $sp, 0x200
-            ",
-            maybe_cfi!(".cfi_offset 1, -16"), // ra
-            "
-            st.d $zero, $sp, 0x0
-            st.d $ra, $sp, 0x8
-            st.d $tp, $sp, 0x10
-            st.d $t0, $sp, 0x18
-            st.d $r21, $sp, 0xa8 // reserved
-            st.d $fp, $sp, 0xb0
-            st.d $s0, $sp, 0xb8
-            st.d $s1, $sp, 0xc0
-            st.d $s2, $sp, 0xc8
-            st.d $s3, $sp, 0xd0
-            st.d $s4, $sp, 0xd8
-            st.d $s5, $sp, 0xe0
-            st.d $s6, $sp, 0xe8
-            st.d $s7, $sp, 0xf0
-            st.d $s8, $sp, 0xf8
-            ",
-            save_regs!(maybe_save_fp($($fp)?)),
-            "
-            move $t0, $a0
-            move $a0, $sp
-
-            jirl $ra, $t0, 0
-
-            ld.d $ra, $sp, 0x200
-            addi.d $sp, $sp, 0x210
-            ",
-            maybe_cfi!(".cfi_def_cfa_offset 0"),
-            maybe_cfi!(".cfi_restore 1"), // ra
-            "
-            ret
-            ",
-            maybe_cfi!(".cfi_endproc"),
-        )
+macro_rules! code {
+    (save_gp) => {
+        "
+        st.d $zero, $sp, 0x0
+        st.d $ra, $sp, 0x8
+        st.d $tp, $sp, 0x10
+        st.d $t0, $sp, 0x18
+        st.d $r21, $sp, 0xa8 // reserved
+        st.d $fp, $sp, 0xb0
+        st.d $s0, $sp, 0xb8
+        st.d $s1, $sp, 0xc0
+        st.d $s2, $sp, 0xc8
+        st.d $s3, $sp, 0xd0
+        st.d $s4, $sp, 0xd8
+        st.d $s5, $sp, 0xe0
+        st.d $s6, $sp, 0xe8
+        st.d $s7, $sp, 0xf0
+        st.d $s8, $sp, 0xf8
+        "
     };
-    (maybe_save_fp(fp)) => {
+    (save_fp) => {
         "
         fst.d $fs0, $sp, 0x1c0
         fst.d $fs1, $sp, 0x1c8
@@ -118,56 +94,41 @@ macro_rules! save_regs {
         fst.d $fs7, $sp, 0x1f8
         "
     };
-    (maybe_save_fp()) => {
-        ""
+    (restore_gp) => {
+        "
+        ld.d $ra, $a0, 0x8
+        ld.d $tp, $a0, 0x10
+        ld.d $sp, $a0, 0x18
+        ld.d $a1, $a0, 0x28
+        ld.d $a2, $a0, 0x30
+        ld.d $a3, $a0, 0x38
+        ld.d $a4, $a0, 0x40
+        ld.d $a5, $a0, 0x48
+        ld.d $a6, $a0, 0x50
+        ld.d $a7, $a0, 0x58
+        ld.d $t0, $a0, 0x60
+        ld.d $t1, $a0, 0x68
+        ld.d $t2, $a0, 0x70
+        ld.d $t3, $a0, 0x78
+        ld.d $t4, $a0, 0x80
+        ld.d $t5, $a0, 0x88
+        ld.d $t6, $a0, 0x90
+        ld.d $t7, $a0, 0x98
+        ld.d $t8, $a0, 0xa0
+        ld.d $r21, $a0, 0xa8 // reserved
+        ld.d $fp, $a0, 0xb0
+        ld.d $s0, $a0, 0xb8
+        ld.d $s1, $a0, 0xc0
+        ld.d $s2, $a0, 0xc8
+        ld.d $s3, $a0, 0xd0
+        ld.d $s4, $a0, 0xd8
+        ld.d $s5, $a0, 0xe0
+        ld.d $s6, $a0, 0xe8
+        ld.d $s7, $a0, 0xf0
+        ld.d $s8, $a0, 0xf8
+        "
     };
-}
-
-macro_rules! restore_regs {
-    ($ctx:expr, gp$(, $fp:ident)?) => {
-        core::arch::asm!(
-            restore_regs!(maybe_restore_fp($($fp)?)),
-            "
-            ld.d $ra, $a0, 0x8
-            ld.d $tp, $a0, 0x10
-            ld.d $sp, $a0, 0x18
-            ld.d $a1, $a0, 0x28
-            ld.d $a2, $a0, 0x30
-            ld.d $a3, $a0, 0x38
-            ld.d $a4, $a0, 0x40
-            ld.d $a5, $a0, 0x48
-            ld.d $a6, $a0, 0x50
-            ld.d $a7, $a0, 0x58
-            ld.d $t0, $a0, 0x60
-            ld.d $t1, $a0, 0x68
-            ld.d $t2, $a0, 0x70
-            ld.d $t3, $a0, 0x78
-            ld.d $t4, $a0, 0x80
-            ld.d $t5, $a0, 0x88
-            ld.d $t6, $a0, 0x90
-            ld.d $t7, $a0, 0x98
-            ld.d $t8, $a0, 0xa0
-            ld.d $r21, $a0, 0xa8 // reserved
-            ld.d $fp, $a0, 0xb0
-            ld.d $s0, $a0, 0xb8
-            ld.d $s1, $a0, 0xc0
-            ld.d $s2, $a0, 0xc8
-            ld.d $s3, $a0, 0xd0
-            ld.d $s4, $a0, 0xd8
-            ld.d $s5, $a0, 0xe0
-            ld.d $s6, $a0, 0xe8
-            ld.d $s7, $a0, 0xf0
-            ld.d $s8, $a0, 0xf8
-            ",
-            "
-            ld.d $a0, $a0, 0x20
-            ret
-            ",
-            in("$a0") $ctx,
-            options(noreturn)
-        )
-    };
-    (maybe_restore_fp(fp)) => {
+    (restore_fp) => {
         "
         fld.d $fa0, $a0, 0x100
         fld.d $fa1, $a0, 0x108
@@ -203,27 +164,87 @@ macro_rules! restore_regs {
         fld.d $fs7, $a0, 0x1f8
         "
     };
-    (maybe_restore_fp()) => {
-        ""
-    };
 }
 
 #[unsafe(naked)]
 pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), ptr: *mut ()) {
-    #[allow(unused_unsafe)]
-    unsafe {
-        #[cfg(target_feature = "d")]
-        save_regs!(gp, fp);
-        #[cfg(not(target_feature = "d"))]
-        save_regs!(gp);
-    }
+    #[cfg(target_feature = "d")]
+    core::arch::naked_asm!(
+        maybe_cfi!(".cfi_startproc"),
+        "
+        move $t0, $sp
+        addi.d $sp, $sp, -0x210
+        ",
+        maybe_cfi!(".cfi_def_cfa_offset 0x210"),
+        "
+        st.d $ra, $sp, 0x200
+        ",
+        maybe_cfi!(".cfi_offset ra, -16"),
+        code!(save_gp),
+        code!(save_fp),
+        "
+        move $t0, $a0
+        move $a0, $sp
+        jirl $ra, $t0, 0
+        ld.d $ra, $sp, 0x200
+        addi.d $sp, $sp, 0x210
+        ",
+        maybe_cfi!(".cfi_def_cfa_offset 0"),
+        maybe_cfi!(".cfi_restore ra"),
+        "ret",
+        maybe_cfi!(".cfi_endproc"),
+    );
+    #[cfg(not(target_feature = "d"))]
+    core::arch::naked_asm!(
+        maybe_cfi!(".cfi_startproc"),
+        "
+        move $t0, $sp
+        addi.d $sp, $sp, -0x110
+        ",
+        maybe_cfi!(".cfi_def_cfa_offset 0x110"),
+        "
+        st.d $ra, $sp, 0x100
+        ",
+        maybe_cfi!(".cfi_offset ra, -16"),
+        code!(save_gp),
+        "
+        move $t0, $a0
+        move $a0, $sp
+        jirl $ra, $t0, 0
+        ld.d $ra, $sp, 0x100
+        addi.d $sp, $sp, 0x110
+        ",
+        maybe_cfi!(".cfi_def_cfa_offset 0"),
+        maybe_cfi!(".cfi_restore ra"),
+        "ret",
+        maybe_cfi!(".cfi_endproc"),
+    );
 }
 
 pub unsafe fn restore_context(ctx: &Context) -> ! {
+    #[cfg(target_feature = "d")]
     unsafe {
-        #[cfg(target_feature = "d")]
-        restore_regs!(ctx, gp, fp);
-        #[cfg(not(target_feature = "d"))]
-        restore_regs!(ctx, gp);
+        core::arch::asm!(
+            code!(restore_fp),
+            code!(restore_gp),
+            "
+            ld.d $a0, $a0, 0x20
+            ret
+            ",
+            in("$a0") ctx,
+            options(noreturn)
+        );
+    }
+    #[cfg(not(target_feature = "d"))]
+    unsafe {
+        core::arch::asm!(
+            code!(restore_gp),
+            "
+            ld.d $a0, $a0, 0x20
+            ret
+            ",
+            in("$a0") ctx,
+            options(noreturn)
+        );
     }
 }

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -56,7 +56,71 @@ impl ops::IndexMut<gimli::Register> for Context {
     }
 }
 
-macro_rules! ctx_helper {
+macro_rules! save_regs {
+    (gp$(, $fp:ident)?) => {
+        core::arch::naked_asm!(
+            maybe_cfi!(".cfi_startproc"),
+            "
+            move $r12, $r3
+            addi.d $r3, $r3, -0x210
+            ",
+            maybe_cfi!(".cfi_def_cfa_offset 0x210"),
+            "
+            st.d $r1, $r3, 0x200
+            ",
+            maybe_cfi!(".cfi_offset 1, -16"), // ra
+            helper!(save_gp),
+            save_regs!(maybe_save_fp($($fp)?)),
+            "
+            move $r12, $r4
+            move $r4, $r3 // argument a0 pointing the ctx base
+
+            addi.d $r13, $r3, 0x210
+            st.d $r13, $r3, 0x18 // save sp
+
+            jirl $r1, $r12, 0 // call f
+
+            ld.d $r1, $r3, 0x200
+            addi.d $r3, $r3, 0x210 // restore ra and sp
+            ",
+            maybe_cfi!(".cfi_def_cfa_offset 0"),
+            maybe_cfi!(".cfi_restore 1"), // ra
+            "
+            ret
+            ",
+            maybe_cfi!(".cfi_endproc"),
+        )
+    };
+    (maybe_save_fp(fp)) => {
+        helper!(save_fp)
+    };
+    (maybe_save_fp()) => {
+        ""
+    };
+}
+
+macro_rules! restore_regs {
+    ($ctx:expr, gp$(, $fp:ident)?) => {
+        core::arch::asm!(
+            restore_regs!(maybe_restore_fp($($fp)?)),
+            helper!(restore_gp),
+            "
+            ld.d $r4, $r4, 0x20
+            ret
+            ",
+            in("$r4") $ctx,
+            options(noreturn)
+        )
+    };
+    (maybe_restore_fp(fp)) => {
+        helper!(restore_fp)
+    };
+    (maybe_restore_fp()) => {
+        ""
+    };
+}
+
+macro_rules! helper {
     // see https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html for ABI conventions
     (save_gp) => {
         "
@@ -94,7 +158,7 @@ macro_rules! ctx_helper {
         ld.d $r1, $r4, 0x8 // ra
         ld.d $r2, $r4, 0x10 // tp
         ld.d $r3, $r4, 0x18 // sp
-        // a0 is restored later
+        // r4(a0) is restored later
         ld.d $r5, $r4, 0x28 // a1
         ld.d $r6, $r4, 0x30 // a2
         ld.d $r7, $r4, 0x38 // a3
@@ -166,52 +230,18 @@ macro_rules! ctx_helper {
 pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), ptr: *mut ()) {
     #[allow(unused_unsafe)]
     unsafe {
-        core::arch::naked_asm!(
-            maybe_cfi!(".cfi_startproc"),
-            "
-            move $r12, $r3
-            addi.d $r3, $r3, -0x210
-            ",
-            maybe_cfi!(".cfi_def_cfa_offset 0x210"),
-            "
-            st.d $r1, $r3, 0x200
-            ",
-            maybe_cfi!(".cfi_offset 1, -16"), // ra
-            ctx_helper!(save_gp),
-            ctx_helper!(save_fp),
-            "
-            move $r12, $r4
-            move $r4, $r3 // argument a0 pointing the ctx base
-
-            addi.d $r13, $r3, 0x210
-            st.d $r13, $r3, 0x18 // save sp
-
-            jirl $r1, $r12, 0 // call f
-
-            ld.d $r1, $r3, 0x200
-            addi.d $r3, $r3, 0x210 // restore ra and sp
-            ",
-            maybe_cfi!(".cfi_def_cfa_offset 0"),
-            maybe_cfi!(".cfi_restore 1"), // ra
-            "
-            ret
-            ",
-            maybe_cfi!(".cfi_endproc"),
-        )
+        #[cfg(target_feature = "d")]
+        save_regs!(gp, fp);
+        #[cfg(not(target_feature = "d"))]
+        save_regs!(gp);
     }
 }
 
 pub unsafe fn restore_context(ctx: &Context) -> ! {
     unsafe {
-        core::arch::asm!(
-            ctx_helper!(restore_gp),
-            ctx_helper!(restore_fp),
-            "
-            ld.d $r4, $r4, 0x20
-            ret
-            ",
-            in("$r4") ctx,
-            options(noreturn)
-        );
+        #[cfg(target_feature = "d")]
+        restore_regs!(ctx, gp, fp);
+        #[cfg(not(target_feature = "d"))]
+        restore_regs!(ctx, gp);
     }
 }

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -1,4 +1,4 @@
-use core::fmt::{self, Write};
+use core::fmt;
 use core::ops;
 use gimli::{LoongArch, Register};
 
@@ -58,104 +58,105 @@ impl ops::IndexMut<gimli::Register> for Context {
 }
 
 macro_rules! ctx_helper {
-    (savegp) => {
+    // see https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html for ABI conventions
+    (save_gp) => {
         "
-        st.d $r0, $r3, 0x0
-        st.d $r1, $r3, 0x8
-        st.d $r2, $r3, 0x10
-        st.d $r3, $r3, 0x18
-        st.d $r22, $r3, 0xB0
-        st.d $r23, $r3, 0xB8
-        st.d $r24, $r3, 0xC0
-        st.d $r25, $r3, 0xC8
-        st.d $r26, $r3, 0xD0
-        st.d $r27, $r3, 0xD8
-        st.d $r28, $r3, 0xE0
-        st.d $r29, $r3, 0xE8
-        st.d $r30, $r3, 0xF0
-        st.d $r31, $r3, 0xF8
-        "
-    };
-    (savefp) => {
-        "
-        fst.d $f24, $r3, 0x1C0
-        fst.d $f25, $r3, 0x1C8
-        fst.d $f26, $r3, 0x1D0
-        fst.d $f27, $r3, 0x1D8
-        fst.d $f28, $r3, 0x1E0
-        fst.d $f29, $r3, 0x1E8
-        fst.d $f30, $r3, 0x1F0
-        fst.d $f31, $r3, 0x1F8
+        st.d $r1, $r3, 0x8 // ra
+        st.d $r2, $r3, 0x10 // tp
+        // sp is saved later
+        st.d $r22, $r3, 0xb0 // fp
+        st.d $r23, $r3, 0xb8 // s0
+        st.d $r24, $r3, 0xc0 // s1
+        st.d $r25, $r3, 0xc8 // s2
+        st.d $r26, $r3, 0xd0 // s3
+        st.d $r27, $r3, 0xd8 // s4
+        st.d $r28, $r3, 0xe0 // s5
+        st.d $r29, $r3, 0xe8 // s6
+        st.d $r30, $r3, 0xf0 // s7
+        st.d $r31, $r3, 0xf8 // s8
         "
     };
-    (restoregp) => {
+    (save_fp) => {
         "
-        ld.d $r1, $r4, 0x8
-        ld.d $r2, $r4, 0x10
-        ld.d $r3, $r4, 0x18
-        ld.d $r5, $r4, 0x28
-        ld.d $r6, $r4, 0x30
-        ld.d $r7, $r4, 0x38
-        ld.d $r8, $r4, 0x40
-        ld.d $r9, $r4, 0x48
-        ld.d $r10, $r4, 0x50
-        ld.d $r11, $r4, 0x58
-        ld.d $r12, $r4, 0x60
-        ld.d $r13, $r4, 0x68
-        ld.d $r14, $r4, 0x70
-        ld.d $r15, $r4, 0x78
-        ld.d $r16, $r4, 0x80
-        ld.d $r17, $r4, 0x88
-        ld.d $r18, $r4, 0x90
-        ld.d $r19, $r4, 0x98
-        ld.d $r20, $r4, 0xA0
-        ld.d $r21, $r4, 0xA8
-        ld.d $r22, $r4, 0xB0
-        ld.d $r23, $r4, 0xB8
-        ld.d $r24, $r4, 0xC0
-        ld.d $r25, $r4, 0xC8
-        ld.d $r26, $r4, 0xD0
-        ld.d $r27, $r4, 0xD8
-        ld.d $r28, $r4, 0xE0
-        ld.d $r29, $r4, 0xE8
-        ld.d $r30, $r4, 0xF0
-        ld.d $r31, $r4, 0xF8
+        fst.d $f24, $r3, 0x1c0 // fs0
+        fst.d $f25, $r3, 0x1c8 // fs1
+        fst.d $f26, $r3, 0x1d0 // fs2
+        fst.d $f27, $r3, 0x1d8 // fs3
+        fst.d $f28, $r3, 0x1e0 // fs4
+        fst.d $f29, $r3, 0x1e8 // fs5
+        fst.d $f30, $r3, 0x1f0 // fs6
+        fst.d $f31, $r3, 0x1f8 // fs7
         "
     };
-    (restorefp) => {
+    (restore_gp) => {
         "
-        fld.d $f0, $r4, 0x100
-        fld.d $f1, $r4, 0x108
-        fld.d $f2, $r4, 0x110
-        fld.d $f3, $r4, 0x118
-        fld.d $f4, $r4, 0x120
-        fld.d $f5, $r4, 0x128
-        fld.d $f6, $r4, 0x130
-        fld.d $f7, $r4, 0x138
-        fld.d $f8, $r4, 0x140
-        fld.d $f9, $r4, 0x148
-        fld.d $f10, $r4, 0x150
-        fld.d $f11, $r4, 0x158
-        fld.d $f12, $r4, 0x160
-        fld.d $f13, $r4, 0x168
-        fld.d $f14, $r4, 0x170
-        fld.d $f15, $r4, 0x178
-        fld.d $f16, $r4, 0x180
-        fld.d $f17, $r4, 0x188
-        fld.d $f18, $r4, 0x190
-        fld.d $f19, $r4, 0x198
-        fld.d $f20, $r4, 0x1A0
-        fld.d $f21, $r4, 0x1A8
-        fld.d $f22, $r4, 0x1B0
-        fld.d $f23, $r4, 0x1B8
-        fld.d $f24, $r4, 0x1C0
-        fld.d $f25, $r4, 0x1C8
-        fld.d $f26, $r4, 0x1D0
-        fld.d $f27, $r4, 0x1D8
-        fld.d $f28, $r4, 0x1E0
-        fld.d $f29, $r4, 0x1E8
-        fld.d $f30, $r4, 0x1F0
-        fld.d $f31, $r4, 0x1F8
+        ld.d $r1, $r4, 0x8 // ra
+        ld.d $r2, $r4, 0x10 // tp
+        ld.d $r3, $r4, 0x18 // sp
+        // a0 is restored later
+        ld.d $r5, $r4, 0x28 // a1
+        ld.d $r6, $r4, 0x30 // a2
+        ld.d $r7, $r4, 0x38 // a3
+        ld.d $r8, $r4, 0x40 // a4
+        ld.d $r9, $r4, 0x48 // a5
+        ld.d $r10, $r4, 0x50 // a6
+        ld.d $r11, $r4, 0x58 // a7
+        ld.d $r12, $r4, 0x60 // t0
+        ld.d $r13, $r4, 0x68 // t1
+        ld.d $r14, $r4, 0x70 // t2
+        ld.d $r15, $r4, 0x78 // t3
+        ld.d $r16, $r4, 0x80 // t4
+        ld.d $r17, $r4, 0x88 // t5
+        ld.d $r18, $r4, 0x90 // t6
+        ld.d $r19, $r4, 0x98 // t7
+        ld.d $r20, $r4, 0xa0 // t8
+        ld.d $r21, $r4, 0xa8 // reserved
+        ld.d $r22, $r4, 0xb0 // fp
+        ld.d $r23, $r4, 0xb8 // s0
+        ld.d $r24, $r4, 0xc0 // s1
+        ld.d $r25, $r4, 0xc8 // s2
+        ld.d $r26, $r4, 0xd0 // s3
+        ld.d $r27, $r4, 0xd8 // s4
+        ld.d $r28, $r4, 0xe0 // s5
+        ld.d $r29, $r4, 0xe8 // s6
+        ld.d $r30, $r4, 0xf0 // s7
+        ld.d $r31, $r4, 0xf8 // s8
+        "
+    };
+    (restore_fp) => {
+        "
+        fld.d $f0, $r4, 0x100 // fa0
+        fld.d $f1, $r4, 0x108 // fa1
+        fld.d $f2, $r4, 0x110 // fa2
+        fld.d $f3, $r4, 0x118 // fa3
+        fld.d $f4, $r4, 0x120 // fa4
+        fld.d $f5, $r4, 0x128 // fa5
+        fld.d $f6, $r4, 0x130 // fa6
+        fld.d $f7, $r4, 0x138 // fa7
+        fld.d $f8, $r4, 0x140 // ft0
+        fld.d $f9, $r4, 0x148 // ft1
+        fld.d $f10, $r4, 0x150 // ft2
+        fld.d $f11, $r4, 0x158 // ft3
+        fld.d $f12, $r4, 0x160 // ft4
+        fld.d $f13, $r4, 0x168 // ft5
+        fld.d $f14, $r4, 0x170 // ft6
+        fld.d $f15, $r4, 0x178 // ft7
+        fld.d $f16, $r4, 0x180 // ft8
+        fld.d $f17, $r4, 0x188 // ft9
+        fld.d $f18, $r4, 0x190 // ft10
+        fld.d $f19, $r4, 0x198 // ft11
+        fld.d $f20, $r4, 0x1a0 // ft12
+        fld.d $f21, $r4, 0x1a8 // ft13
+        fld.d $f22, $r4, 0x1b0 // ft14
+        fld.d $f23, $r4, 0x1b8 // ft15
+        fld.d $f24, $r4, 0x1c0 // fs0
+        fld.d $f25, $r4, 0x1c8 // fs1
+        fld.d $f26, $r4, 0x1d0 // fs2
+        fld.d $f27, $r4, 0x1d8 // fs3
+        fld.d $f28, $r4, 0x1e0 // fs4
+        fld.d $f29, $r4, 0x1e8 // fs5
+        fld.d $f30, $r4, 0x1f0 // fs6
+        fld.d $f31, $r4, 0x1f8 // fs7
         "
     };
 }
@@ -174,18 +175,23 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             "
             st.d $r1, $r3, 0x200
             ",
-            maybe_cfi!(".cfi_offset $r1, -16"),
-            ctx_helper!(savegp),
-            ctx_helper!(savefp),
+            maybe_cfi!(".cfi_offset 1, -16"), // ra
+            ctx_helper!(save_gp),
+            ctx_helper!(save_fp),
             "
             move $r12, $r4
-            move $r4, $r3
-            jirl $r1, $r12, 0
+            move $r4, $r3 // argument a0 pointing the ctx base
+
+            addi.d $r13, $r3, 0x210
+            st.d $r13, $r3, 0x18 // save sp
+
+            jirl $r1, $r12, 0 // call f
+
             ld.d $r1, $r3, 0x200
-            addi.d $r3, $r3, 0x210
+            addi.d $r3, $r3, 0x210 // restore ra and sp
             ",
             maybe_cfi!(".cfi_def_cfa_offset 0"),
-            maybe_cfi!(".cfi_restore $r1"),
+            maybe_cfi!(".cfi_restore 1"), // ra
             "
             ret
             ",
@@ -197,8 +203,8 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
 pub unsafe fn restore_context(ctx: &Context) -> ! {
     unsafe {
         core::arch::asm!(
-            ctx_helper!(restoregp),
-            ctx_helper!(restorefp),
+            ctx_helper!(restore_gp),
+            ctx_helper!(restore_fp),
             "
             ld.d $r4, $r4, 0x20
             ret

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use core::fmt::{self, Write};
 use core::ops;
 use gimli::{LoongArch, Register};
 
@@ -21,14 +21,14 @@ impl fmt::Debug for Context {
         for i in 0..=31 {
             fmt.field(
                 LoongArch::register_name(Register(i as _)).unwrap(),
-                &self.gp[i],
+                &format_args!("{:#x}", self.gp[i]),
             );
         }
         fmt.field("sp", &self.gp[3]);
         for i in 0..=31 {
             fmt.field(
                 LoongArch::register_name(Register((i + 32) as _)).unwrap(),
-                &self.fp[i],
+                &format_args!("{:#x}", self.fp[i]),
             );
         }
         fmt.finish()
@@ -57,116 +57,72 @@ impl ops::IndexMut<gimli::Register> for Context {
     }
 }
 
-macro_rules! save {
-    (gp, fp) => {
-        core::arch::naked_asm!(
-            maybe_cfi!(".cfi_startproc"),
-            "addi.d $r3, $r3, -16",
-            maybe_cfi!(".cfi_def_cfa_offset 16"),
-            "st.d $r1, $r3, 0",
-            maybe_cfi!(".cfi_offset $r1, 0"),
-            "st.d $r22, $r3, 8",
-            maybe_cfi!(".cfi_offset $r22, 8"),
-            "addi.d $r3, $r3, -512",
-            maybe_cfi!(".cfi_def_cfa_offset 528"),
-            "
-            move $r8, $r4
-            move $r4, $r3
-            ",
-            save!(savefp),
-            "
-            st.d $r23, $r3, 0x18
-            st.d $r24, $r3, 0x20
-            st.d $r25, $r3, 0x28
-            st.d $r26, $r3, 0x30
-            st.d $r27, $r3, 0x38
-            st.d $r28, $r3, 0x40
-            st.d $r29, $r3, 0x48
-            st.d $r30, $r3, 0x50
-            st.d $r31, $r3, 0x58
-            addi.d $r2, $r3, 528
-            st.d $r2, $r3, 0x60
-
-            jirl $r1, $r8, 0
-
-            addi.d $r3, $r3, 512
-            ",
-            maybe_cfi!(".cfi_def_cfa_offset 16"),
-            "ld.d $r1, $r3, 0",
-            maybe_cfi!(".cfi_restore $r1"),
-            "ld.d $r22, $r3, 8",
-            maybe_cfi!(".cfi_restore $r22"),
-            "addi.d $r3, $r3, 16",
-            maybe_cfi!(".cfi_def_cfa_offset 0"),
-            "ret",
-            maybe_cfi!(".cfi_endproc"),
-        );
+macro_rules! ctx_helper {
+    (savegp) => {
+        "
+        st.d $r0, $r3, 0x0
+        st.d $r1, $r3, 0x8
+        st.d $r2, $r3, 0x10
+        st.d $r3, $r3, 0x18
+        st.d $r22, $r3, 0xB0
+        st.d $r23, $r3, 0xB8
+        st.d $r24, $r3, 0xC0
+        st.d $r25, $r3, 0xC8
+        st.d $r26, $r3, 0xD0
+        st.d $r27, $r3, 0xD8
+        st.d $r28, $r3, 0xE0
+        st.d $r29, $r3, 0xE8
+        st.d $r30, $r3, 0xF0
+        st.d $r31, $r3, 0xF8
+        "
     };
     (savefp) => {
         "
-        fst.d $f24, $r3, 0x140
-        fst.d $f25, $r3, 0x148
-        fst.d $f26, $r3, 0x150
-        fst.d $f27, $r3, 0x158
-        fst.d $f28, $r3, 0x160
-        fst.d $f29, $r3, 0x168
-        fst.d $f30, $r3, 0x170
-        fst.d $f31, $r3, 0x178
+        fst.d $f24, $r3, 0x1C0
+        fst.d $f25, $r3, 0x1C8
+        fst.d $f26, $r3, 0x1D0
+        fst.d $f27, $r3, 0x1D8
+        fst.d $f28, $r3, 0x1E0
+        fst.d $f29, $r3, 0x1E8
+        fst.d $f30, $r3, 0x1F0
+        fst.d $f31, $r3, 0x1F8
         "
     };
-}
-
-#[unsafe(naked)]
-pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), ptr: *mut ()) {
-    unsafe {
-        save!(gp, fp);
-    }
-}
-
-macro_rules! restore {
-    ($ctx:expr, gp, fp) => {
-        core::arch::asm!(
-            restore!(restore),
-            "
-            ld.d $r2, $r4, 0x10
-            ld.d $r5, $r4, 0x18
-            ld.d $r6, $r4, 0x20
-            ld.d $r7, $r4, 0x28
-            ld.d $r8, $r4, 0x30
-            ld.d $r9, $r4, 0x38
-            ld.d $r10, $r4, 0x40
-            ld.d $r11, $r4, 0x48
-            ld.d $r12, $r4, 0x50
-            ld.d $r13, $r4, 0x58
-            ld.d $r14, $r4, 0x60
-            ld.d $r15, $r4, 0x68
-            ld.d $r16, $r4, 0x70
-            ld.d $r17, $r4, 0x78
-            ld.d $r18, $r4, 0x80
-            ld.d $r19, $r4, 0x88
-            ld.d $r20, $r4, 0x90
-            ld.d $r21, $r4, 0x98
-            ld.d $r22, $r4, 0xA0
-            ld.d $r23, $r4, 0xA8
-            ld.d $r24, $r4, 0xB0
-            ld.d $r25, $r4, 0xB8
-            ld.d $r26, $r4, 0xC0
-            ld.d $r27, $r4, 0xC8
-            ld.d $r28, $r4, 0xD0
-            ld.d $r29, $r4, 0xD8
-            ld.d $r30, $r4, 0xE0
-            ld.d $r31, $r4, 0xE8
-            ld.d $r1, $r4, 0xF0
-
-            ld.d $r3, $r4, 0x00
-            ld.d $r4, $r4, 0x08
-            ret
-            ",
-            in("$r4") $ctx,
-            options(noreturn)
-        );
+    (restoregp) => {
+        "
+        ld.d $r1, $r4, 0x8
+        ld.d $r2, $r4, 0x10
+        ld.d $r3, $r4, 0x18
+        ld.d $r5, $r4, 0x28
+        ld.d $r6, $r4, 0x30
+        ld.d $r7, $r4, 0x38
+        ld.d $r8, $r4, 0x40
+        ld.d $r9, $r4, 0x48
+        ld.d $r10, $r4, 0x50
+        ld.d $r11, $r4, 0x58
+        ld.d $r12, $r4, 0x60
+        ld.d $r13, $r4, 0x68
+        ld.d $r14, $r4, 0x70
+        ld.d $r15, $r4, 0x78
+        ld.d $r16, $r4, 0x80
+        ld.d $r17, $r4, 0x88
+        ld.d $r18, $r4, 0x90
+        ld.d $r19, $r4, 0x98
+        ld.d $r20, $r4, 0xA0
+        ld.d $r21, $r4, 0xA8
+        ld.d $r22, $r4, 0xB0
+        ld.d $r23, $r4, 0xB8
+        ld.d $r24, $r4, 0xC0
+        ld.d $r25, $r4, 0xC8
+        ld.d $r26, $r4, 0xD0
+        ld.d $r27, $r4, 0xD8
+        ld.d $r28, $r4, 0xE0
+        ld.d $r29, $r4, 0xE8
+        ld.d $r30, $r4, 0xF0
+        ld.d $r31, $r4, 0xF8
+        "
     };
-    (restore) => {
+    (restorefp) => {
         "
         fld.d $f0, $r4, 0x100
         fld.d $f1, $r4, 0x108
@@ -204,8 +160,50 @@ macro_rules! restore {
     };
 }
 
+#[unsafe(naked)]
+pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), ptr: *mut ()) {
+    unsafe {
+        core::arch::naked_asm!(
+            maybe_cfi!(".cfi_startproc"),
+            "
+            move $r12, $r3
+            addi.d $r3, $r3, -0x210
+            ",
+            maybe_cfi!(".cfi_def_cfa_offset 0x210"),
+            "
+            st.d $r1, $r3, 0x200
+            ",
+            maybe_cfi!(".cfi_offset $r1, -16"),
+            ctx_helper!(savegp),
+            ctx_helper!(savefp),
+            "
+            move $r12, $r4
+            move $r4, $r3
+            jirl $r1, $r12, 0
+            ld.d $r1, $r3, 0x200
+            addi.d $r3, $r3, 0x210
+            ",
+            maybe_cfi!(".cfi_def_cfa_offset 0"),
+            maybe_cfi!(".cfi_restore $r1"),
+            "
+            ret
+            ",
+            maybe_cfi!(".cfi_endproc"),
+        )
+    }
+}
+
 pub unsafe fn restore_context(ctx: &Context) -> ! {
     unsafe {
-        restore!(ctx, gp, fp);
+        core::arch::asm!(
+            ctx_helper!(restoregp),
+            ctx_helper!(restorefp),
+            "
+            ld.d $r4, $r4, 0x20
+            ret
+            ",
+            in("$r4") ctx,
+            options(noreturn)
+        );
     }
 }

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -1,0 +1,100 @@
+use core::fmt;
+use core::ops;
+use gimli::{LoongArch, Register};
+
+use super::maybe_cfi;
+
+pub const MAX_REG_RULES: usize = 0; // TODO: find the GCC's MAX_REG_RULES for loongarch64
+
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct Context {
+    pub gp: [usize; 32],
+    // sp is gp[3]
+    pub fp: [usize; 32],
+}
+
+impl fmt::Debug for Context {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut fmt = fmt.debug_struct("Context");
+        for i in 0..=31 {
+            fmt.field(
+                LoongArch::register_name(Register(i as _)).unwrap(),
+                &self.gp[i],
+            );
+        }
+        fmt.field("sp", &self.gp[3]);
+        for i in 0..=31 {
+            fmt.field(
+                LoongArch::register_name(Register((i + 32) as _)).unwrap(),
+                &self.fp[i],
+            );
+        }
+        fmt.finish()
+    }
+}
+
+impl ops::Index<Register> for Context {
+    type Output = usize;
+
+    fn index(&self, reg: Register) -> &usize {
+        match reg {
+            Register(0..=31) => &self.gp[reg.0 as usize],
+            Register(32..=63) => &self.fp[(reg.0 - 32) as usize],
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl ops::IndexMut<gimli::Register> for Context {
+    fn index_mut(&mut self, reg: Register) -> &mut usize {
+        match reg {
+            Register(0..=31) => &mut self.gp[reg.0 as usize],
+            Register(32..=63) => &mut self.fp[(reg.0 - 32) as usize],
+            _ => unimplemented!(),
+        }
+    }
+}
+
+macro_rules! save {
+    (gp$(, $fp:ident)?) => {
+        core::arch::naked_asm!("addi.d $r3, $r3, -16", "ret",);
+    };
+    (maybesavefp(fp)) => {
+        "
+        fst.d $f24, ($r3, 0x140)
+        "
+    };
+    (maybesavefp()) => {
+        ""
+    };
+}
+
+#[unsafe(naked)]
+pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), ptr: *mut ()) {
+    unsafe {
+        save!(gp, fp);
+    }
+}
+
+macro_rules! restore {
+    ($ctx:expr, gp$(, $fp:ident)?) => {
+        core::arch::asm!(
+        "addi.d $r3, $r3, -16",
+        in("$r1") $ctx,
+        options(noreturn));
+    };
+    (mayberestore(fp)) => {
+        "
+        "
+    };
+    (mayberestore()) => {
+        ""
+    };
+}
+
+pub unsafe fn restore_context(ctx: &Context) -> ! {
+    unsafe {
+        restore!(ctx, gp, fp);
+    }
+}

--- a/src/unwinder/arch/mod.rs
+++ b/src/unwinder/arch/mod.rs
@@ -23,12 +23,18 @@ mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::*;
 
+#[cfg(target_arch = "loongarch64")]
+mod loongarch64;
+#[cfg(target_arch = "loongarch64")]
+pub use loongarch64::*;
+
 #[cfg(not(any(
     target_arch = "x86_64",
     target_arch = "x86",
     target_arch = "riscv64",
     target_arch = "riscv32",
-    target_arch = "aarch64"
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
 )))]
 compile_error!("Current architecture is not supported");
 


### PR DESCRIPTION
1. add `loongarch64` assembly codes for unwinding support (https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html)
2. update the Github CI to include tests for the `loongarch64` target