### PR TITLE
Return an error instead of panicking when encountering unsupported registers during unwind

### DIFF
--- a/src/unwinder/arch/aarch64.rs
+++ b/src/unwinder/arch/aarch64.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use core::ops;
 use gimli::{AArch64, Register};
 
 use super::maybe_cfi;
@@ -35,26 +34,22 @@ impl fmt::Debug for Context {
     }
 }
 
-impl ops::Index<Register> for Context {
-    type Output = usize;
-
-    fn index(&self, reg: Register) -> &usize {
+impl Context {
+    pub fn get(&self, reg: Register) -> Option<&usize> {
         match reg {
-            Register(0..=30) => &self.gp[reg.0 as usize],
-            AArch64::SP => &self.sp,
-            Register(64..=95) => &self.fp[(reg.0 - 64) as usize],
-            _ => unimplemented!(),
+            Register(0..=30) => Some(&self.gp[reg.0 as usize]),
+            AArch64::SP => Some(&self.sp),
+            Register(64..=95) => Some(&self.fp[(reg.0 - 64) as usize]),
+            _ => None,
         }
     }
-}
 
-impl ops::IndexMut<gimli::Register> for Context {
-    fn index_mut(&mut self, reg: Register) -> &mut usize {
+    pub fn get_mut(&mut self, reg: Register) -> Option<&mut usize> {
         match reg {
-            Register(0..=30) => &mut self.gp[reg.0 as usize],
-            AArch64::SP => &mut self.sp,
-            Register(64..=95) => &mut self.fp[(reg.0 - 64) as usize],
-            _ => unimplemented!(),
+            Register(0..=30) => Some(&mut self.gp[reg.0 as usize]),
+            AArch64::SP => Some(&mut self.sp),
+            Register(64..=95) => Some(&mut self.fp[(reg.0 - 64) as usize]),
+            _ => None,
         }
     }
 }

--- a/src/unwinder/arch/loongarch64.rs
+++ b/src/unwinder/arch/loongarch64.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use core::ops;
 use gimli::{LoongArch, Register};
 
 use super::maybe_cfi;
@@ -38,26 +37,22 @@ impl fmt::Debug for Context {
     }
 }
 
-impl ops::Index<Register> for Context {
-    type Output = usize;
-
-    fn index(&self, reg: Register) -> &usize {
+impl Context {
+    pub fn get(&self, reg: Register) -> Option<&usize> {
         match reg {
-            Register(0..=31) => &self.gp[reg.0 as usize],
+            Register(0..=31) => Some(&self.gp[reg.0 as usize]),
             #[cfg(target_feature = "d")]
-            Register(32..=63) => &self.fp[(reg.0 - 32) as usize],
-            _ => unimplemented!(),
+            Register(32..=63) => Some(&self.fp[(reg.0 - 32) as usize]),
+            _ => None,
         }
     }
-}
 
-impl ops::IndexMut<gimli::Register> for Context {
-    fn index_mut(&mut self, reg: Register) -> &mut usize {
+    pub fn get_mut(&mut self, reg: Register) -> Option<&mut usize> {
         match reg {
-            Register(0..=31) => &mut self.gp[reg.0 as usize],
+            Register(0..=31) => Some(&mut self.gp[reg.0 as usize]),
             #[cfg(target_feature = "d")]
-            Register(32..=63) => &mut self.fp[(reg.0 - 32) as usize],
-            _ => unimplemented!(),
+            Register(32..=63) => Some(&mut self.fp[(reg.0 - 32) as usize]),
+            _ => None,
         }
     }
 }

--- a/src/unwinder/arch/riscv32.rs
+++ b/src/unwinder/arch/riscv32.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use core::ops;
 use gimli::{Register, RiscV};
 
 use super::maybe_cfi;
@@ -40,26 +39,22 @@ impl fmt::Debug for Context {
     }
 }
 
-impl ops::Index<Register> for Context {
-    type Output = usize;
-
-    fn index(&self, reg: Register) -> &usize {
+impl Context {
+    pub fn get(&self, reg: Register) -> Option<&usize> {
         match reg {
-            Register(0..=31) => &self.gp[reg.0 as usize],
+            Register(0..=31) => Some(&self.gp[reg.0 as usize]),
             // We cannot support indexing fp here. It is 64-bit if D extension is implemented,
             // and 32-bit if only F extension is implemented.
-            _ => unimplemented!(),
+            _ => None,
         }
     }
-}
 
-impl ops::IndexMut<gimli::Register> for Context {
-    fn index_mut(&mut self, reg: Register) -> &mut usize {
+    pub fn get_mut(&mut self, reg: Register) -> Option<&mut usize> {
         match reg {
-            Register(0..=31) => &mut self.gp[reg.0 as usize],
+            Register(0..=31) => Some(&mut self.gp[reg.0 as usize]),
             // We cannot support indexing fp here. It is 64-bit if D extension is implemented,
             // and 32-bit if only F extension is implemented.
-            _ => unimplemented!(),
+            _ => None,
         }
     }
 }

--- a/src/unwinder/arch/riscv64.rs
+++ b/src/unwinder/arch/riscv64.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use core::ops;
 use gimli::{Register, RiscV};
 
 use super::maybe_cfi;
@@ -38,26 +37,22 @@ impl fmt::Debug for Context {
     }
 }
 
-impl ops::Index<Register> for Context {
-    type Output = usize;
-
-    fn index(&self, reg: Register) -> &usize {
+impl Context {
+    pub fn get(&self, reg: Register) -> Option<&usize> {
         match reg {
-            Register(0..=31) => &self.gp[reg.0 as usize],
+            Register(0..=31) => Some(&self.gp[reg.0 as usize]),
             #[cfg(target_feature = "d")]
-            Register(32..=63) => &self.fp[(reg.0 - 32) as usize],
-            _ => unimplemented!(),
+            Register(32..=63) => Some(&self.fp[(reg.0 - 32) as usize]),
+            _ => None,
         }
     }
-}
 
-impl ops::IndexMut<gimli::Register> for Context {
-    fn index_mut(&mut self, reg: Register) -> &mut usize {
+    pub fn get_mut(&mut self, reg: Register) -> Option<&mut usize> {
         match reg {
-            Register(0..=31) => &mut self.gp[reg.0 as usize],
+            Register(0..=31) => Some(&mut self.gp[reg.0 as usize]),
             #[cfg(target_feature = "d")]
-            Register(32..=63) => &mut self.fp[(reg.0 - 32) as usize],
-            _ => unimplemented!(),
+            Register(32..=63) => Some(&mut self.fp[(reg.0 - 32) as usize]),
+            _ => None,
         }
     }
 }

--- a/src/unwinder/arch/x86.rs
+++ b/src/unwinder/arch/x86.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use core::ops;
 use gimli::{Register, X86};
 
 use super::maybe_cfi;
@@ -32,26 +31,22 @@ impl fmt::Debug for Context {
     }
 }
 
-impl ops::Index<Register> for Context {
-    type Output = usize;
-
-    fn index(&self, reg: Register) -> &usize {
+impl Context {
+    pub fn get(&self, reg: Register) -> Option<&usize> {
         match reg {
-            Register(0..=7) => &self.registers[reg.0 as usize],
-            X86::RA => &self.ra,
-            X86::MXCSR => &self.mcxsr,
-            _ => unimplemented!(),
+            Register(0..=7) => Some(&self.registers[reg.0 as usize]),
+            X86::RA => Some(&self.ra),
+            X86::MXCSR => Some(&self.mcxsr),
+            _ => None,
         }
     }
-}
 
-impl ops::IndexMut<gimli::Register> for Context {
-    fn index_mut(&mut self, reg: Register) -> &mut usize {
+    pub fn get_mut(&mut self, reg: Register) -> Option<&mut usize> {
         match reg {
-            Register(0..=7) => &mut self.registers[reg.0 as usize],
-            X86::RA => &mut self.ra,
-            X86::MXCSR => &mut self.mcxsr,
-            _ => unimplemented!(),
+            Register(0..=7) => Some(&mut self.registers[reg.0 as usize]),
+            X86::RA => Some(&mut self.ra),
+            X86::MXCSR => Some(&mut self.mcxsr),
+            _ => None,
         }
     }
 }

--- a/src/unwinder/arch/x86_64.rs
+++ b/src/unwinder/arch/x86_64.rs
@@ -32,29 +32,39 @@ impl fmt::Debug for Context {
     }
 }
 
+impl Context {
+    pub fn get(&self, reg: Register) -> Option<&usize> {
+        match reg {
+            Register(0..=15) => Some(&self.registers[reg.0 as usize]),
+            X86_64::RA => Some(&self.ra),
+            X86_64::MXCSR => Some(&self.mcxsr),
+            X86_64::FCW => Some(&self.fcw),
+            _ => None,
+        }
+    }
+
+    pub fn get_mut(&mut self, reg: Register) -> Option<&mut usize> {
+        match reg {
+            Register(0..=15) => Some(&mut self.registers[reg.0 as usize]),
+            X86_64::RA => Some(&mut self.ra),
+            X86_64::MXCSR => Some(&mut self.mcxsr),
+            X86_64::FCW => Some(&mut self.fcw),
+            _ => None,
+        }
+    }
+}
+
 impl ops::Index<Register> for Context {
     type Output = usize;
 
     fn index(&self, reg: Register) -> &usize {
-        match reg {
-            Register(0..=15) => &self.registers[reg.0 as usize],
-            X86_64::RA => &self.ra,
-            X86_64::MXCSR => &self.mcxsr,
-            X86_64::FCW => &self.fcw,
-            _ => unimplemented!(),
-        }
+        self.get(reg).unwrap()
     }
 }
 
 impl ops::IndexMut<gimli::Register> for Context {
     fn index_mut(&mut self, reg: Register) -> &mut usize {
-        match reg {
-            Register(0..=15) => &mut self.registers[reg.0 as usize],
-            X86_64::RA => &mut self.ra,
-            X86_64::MXCSR => &mut self.mcxsr,
-            X86_64::FCW => &mut self.fcw,
-            _ => unimplemented!(),
-        }
+        self.get_mut(reg).unwrap()
     }
 }
 

--- a/src/unwinder/arch/x86_64.rs
+++ b/src/unwinder/arch/x86_64.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use core::ops;
 use gimli::{Register, X86_64};
 
 use super::maybe_cfi;
@@ -51,20 +50,6 @@ impl Context {
             X86_64::FCW => Some(&mut self.fcw),
             _ => None,
         }
-    }
-}
-
-impl ops::Index<Register> for Context {
-    type Output = usize;
-
-    fn index(&self, reg: Register) -> &usize {
-        self.get(reg).unwrap()
-    }
-}
-
-impl ops::IndexMut<gimli::Register> for Context {
-    fn index_mut(&mut self, reg: Register) -> &mut usize {
-        self.get_mut(reg).unwrap()
     }
 }
 

--- a/src/unwinder/frame.rs
+++ b/src/unwinder/frame.rs
@@ -169,7 +169,10 @@ impl Frame {
                 RegisterRule::Constant(value) => value as usize,
                 _ => unreachable!(),
             };
-            new_ctx[*reg] = value;
+            let Some(reg) = new_ctx.get_mut(*reg) else {
+                return Err(());
+            };
+            *reg = value;
         }
 
         Ok(new_ctx)

--- a/src/unwinder/frame.rs
+++ b/src/unwinder/frame.rs
@@ -131,7 +131,7 @@ impl Frame {
         ctx[Arch::SP] = ctx[Arch::SP].wrapping_add(size as usize);
     }
 
-    pub fn unwind(&self, ctx: &Context) -> Result<Context, gimli::Error> {
+    pub fn unwind(&self, ctx: &Context) -> Result<Context, ()> {
         let row = &self.row;
         let mut new_ctx = ctx.clone();
 
@@ -139,7 +139,7 @@ impl Frame {
             CfaRule::RegisterAndOffset { register, offset } => {
                 ctx[register].wrapping_add(offset as usize)
             }
-            CfaRule::Expression(expr) => self.evaluate_expression(ctx, expr)?,
+            CfaRule::Expression(expr) => self.evaluate_expression(ctx, expr).map_err(drop)?,
         };
 
         new_ctx[Arch::SP] = cfa as _;
@@ -159,10 +159,12 @@ impl Frame {
                 RegisterRule::ValOffset(offset) => cfa.wrapping_add(offset as usize),
                 RegisterRule::Register(r) => ctx[r],
                 RegisterRule::Expression(expr) => {
-                    let addr = self.evaluate_expression(ctx, expr)?;
+                    let addr = self.evaluate_expression(ctx, expr).map_err(drop)?;
                     unsafe { *(addr as *const usize) }
                 }
-                RegisterRule::ValExpression(expr) => self.evaluate_expression(ctx, expr)?,
+                RegisterRule::ValExpression(expr) => {
+                    self.evaluate_expression(ctx, expr).map_err(drop)?
+                }
                 RegisterRule::Architectural => unreachable!(),
                 RegisterRule::Constant(value) => value as usize,
                 _ => unreachable!(),

--- a/src/unwinder/mod.rs
+++ b/src/unwinder/mod.rs
@@ -428,3 +428,17 @@ pub extern "C-unwind" fn _Unwind_Backtrace(
         }
     })
 }
+
+impl core::ops::Index<Register> for Context {
+    type Output = usize;
+
+    fn index(&self, reg: Register) -> &usize {
+        self.get(reg).unwrap()
+    }
+}
+
+impl core::ops::IndexMut<gimli::Register> for Context {
+    fn index_mut(&mut self, reg: Register) -> &mut usize {
+        self.get_mut(reg).unwrap()
+    }
+}


### PR DESCRIPTION
This fixes #55.

I have changed `Frame::unwind` to return a unit error type instead of a gimli error. The error information is currently discarded at all call sites of `Frame::unwind`. I have considered two alternatives:
- introduce a custom error type than can be either a gimli error or an unsupported register error. Given that the information is not used anyway, this feels like needless complexity.
- reuse the `UnsupportedRegister` variant of gimli's error type. This feels misleading, especially in the context of gimli's documentation:
  > Registers larger than `u16` are not supported.

This fixes the problem I had encountered in #55. However, I am unsure of what testing procedures `unwind` uses. I have only run `cargo check` and `cargo test`. The test output looks the same as before my changes.