### PR TITLE
Fix build error due to core::intrinsics::catch_unwind return type change

### DIFF
--- a/src/panicking.rs
+++ b/src/panicking.rs
@@ -39,10 +39,10 @@ pub fn catch_unwind<E: Exception, R, F: FnOnce() -> R>(f: F) -> Result<R, Option
 
     let data_ptr = &mut data as *mut _ as *mut u8;
     unsafe {
-        return if core::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<E>) == 0 {
-            Ok(ManuallyDrop::into_inner(data.r))
-        } else {
+        return if core::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<E>) {
             Err(ManuallyDrop::into_inner(data.p))
+        } else {
+            Ok(ManuallyDrop::into_inner(data.r))
         };
     }
 


### PR DESCRIPTION
The return type of `core::intrinsics::catch_unwind` has been changed in nightly-2026-05-30 by https://github.com/rust-lang/rust/pull/156867.

```
error[E0308]: mismatched types
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/unwinding-0.2.8/src/panicking.rs:42:95
   |
42 |         return if core::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<E>) == 0 {
   |                   ------------------------------------------------------------------------    ^ expected `bool`, found integer
   |                   |
   |                   expected because this is `bool`

```