### PR TITLE
Fix stop callback actions in forced unwind

### DIFF
--- a/src/unwinder/mod.rs
+++ b/src/unwinder/mod.rs
@@ -286,7 +286,7 @@ fn force_unwind_phase2(
             stop(
                 1,
                 UnwindAction::FORCE_UNWIND
-                    | UnwindAction::END_OF_STACK
+                    | UnwindAction::CLEANUP_PHASE
                     | if frame.is_none() {
                         UnwindAction::END_OF_STACK
                     } else {


### PR DESCRIPTION
**Bug**: 
The stop function always gets the `END_OF_STACK` unwind action and never gets
`CLEANUP_PHASE`. Additionally, this renders the `frame.is_none()` block just
below it dead code.

[libgcc](https://github.com/gcc-mirror/gcc/blob/master/libgcc/unwind.inc) and [libunwind](https://github.com/llvm/llvm-project/blob/main/libunwind/src/UnwindLevel1.c) both pass `_UA_FORCE_UNWIND | _UA_CLEANUP_PHASE`
on every frame and add `_UA_END_OF_STACK` only at the actual end.

**Fix**:
This fix replicates libgcc and libunwind behaviour for the stop callback.