### PR TITLE
Fix DW_EH_PE_aligned encoded pointer parsing

### DIFF
--- a/src/personality.rs
+++ b/src/personality.rs
@@ -47,8 +47,9 @@ fn parse_encoded_pointer(
         constants::DW_EH_PE_datarel => _Unwind_GetDataRelBase(unwind_ctx) as u64,
         constants::DW_EH_PE_funcrel => _Unwind_GetRegionStart(unwind_ctx) as u64,
         constants::DW_EH_PE_aligned => {
-            let ptr = input.slice().as_ptr() as u64;
-            ptr.next_multiple_of(size_of::<*const ()>() as u64)
+            let ptr = input.slice().as_ptr() as usize;
+            input.skip(ptr.next_multiple_of(size_of::<usize>()) - ptr)?;
+            0
         }
         _ => unreachable!(),
     };

--- a/src/personality.rs
+++ b/src/personality.rs
@@ -47,6 +47,9 @@ fn parse_encoded_pointer(
         constants::DW_EH_PE_datarel => _Unwind_GetDataRelBase(unwind_ctx) as u64,
         constants::DW_EH_PE_funcrel => _Unwind_GetRegionStart(unwind_ctx) as u64,
         constants::DW_EH_PE_aligned => {
+            // DW_EH_PE_aligned means the same as DW_EH_PE_absptr, but that the address is naturally
+            // aligned.  In reality it's not being emitted (and libunwind doesn't support it) but
+            // it's not tricky to implement so do it anyway.
             let ptr = input.slice().as_ptr() as usize;
             input.skip(ptr.next_multiple_of(size_of::<usize>()) - ptr)?;
             0


### PR DESCRIPTION
**Bug**:
The `DW_EH_PE_aligned` branch in [`parse_encoded_pointer`](https://github.com/nbdd0121/unwinding/blob/trunk/src/personality.rs#L34) fn computes the aligned address but still reads the value from the unaligned position, then adds the aligned address to that wrongly-read value, producing a wrong pointer.

```rust
fn parse_encoded_pointer(
    ...
) -> gimli::Result<Pointer> {
    ...
    let base = match encoding.application() {
        ...
        // Computes the next aligned pointer address, but uses it as a base.
        constants::DW_EH_PE_aligned => {
            let ptr = input.slice().as_ptr() as u64;
            ptr.next_multiple_of(size_of::<*const ()>() as u64)
        }
        ...
    };

    let offset = match encoding.format() {
        // Aligned's format falls into this arm and reads from the still-unaligned cursor.
        constants::DW_EH_PE_absptr => input.read_address(mem::size_of::<usize>() as _),
        ...
    }?;

    // Adds the aligned address as a base on top of a value read from the wrong position.
    let address = base.wrapping_add(offset);
    ...
}
```

**Fix**:
1. Skip the padding so the `read_address` lands on the aligned slot.
2. Set the base to 0, matching what GCC's [`read_encoded_value_with_base`](https://github.com/gcc-mirror/gcc/blob/master/libgcc/unwind-pe.h#L109-L110) does for this case.